### PR TITLE
fix: add missing zod dependency to prevent runtime errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "big.js": "^7.0.1",
     "dotenv": "^16.4.7",
     "stellar-sdk": "^13.3.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/big.js": "^6.2.2",
@@ -39,5 +40,6 @@
   "bugs": {
     "url": "https://github.com/Rabdi-X-Ghewar/stellarTools/issues"
   },
-  "homepage": "https://github.com/Rabdi-X-Ghewar/stellarTools#readme"
+  "homepage": "https://github.com/Rabdi-X-Ghewar/stellarTools#readme",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }


### PR DESCRIPTION
### Fix
- Adds missing `zod` dependency required by LangChain tools
- Prevents build/runtime errors caused by implicit dependency usage

### Changes
- Added `zod` to `package.json`
- Updated lockfile using pnpm

### Reason
`zod` is used internally but not declared as a dependency, which can cause failures for consumers.

### Checklist
- [x] Build passes locally
- [x] No breaking changes

Closes #8

### Notes
- While testing, additional TypeScript typing issues surfaced during build; those will be addressed in a follow-up PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing zod dependency used by LangChain tools to stop build/runtime errors. Also declares the package manager to make installs consistent.

- **Dependencies**
  - Added zod ^4.3.6 to dependencies.
  - Declared packageManager as pnpm@10.28.2.

<sup>Written for commit 43a131972cb440cbcdcbb64a1ad4e5b9ca01a81c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

