### PR TITLE
feat: add mainnet safety guard with explicit opt-in requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,20 @@ This repository contains the **core SDK**, including utilities such as `stellarT
 ---
 
 ## 📦 Installation
-
 ```bash
 npm i stellartools
+```
 or
-
+```bash
 bun add stellartools
 ```
 
+---
+
 ## Quick Start
-```
+
+### Testnet (Safe for Testing)
+```typescript
 import { AgentClient } from "stellar-agentkit";
 
 const agent = new AgentClient({
@@ -57,7 +61,36 @@ await agent.swap({
 });
 ```
 
-## Supported Networks
-Testnet (full support)
-Mainnet (transactions)
+### Mainnet (Real Funds - Requires Explicit Opt-in)
 
+⚠️ **Safety Notice:** Mainnet operations require the `allowMainnet: true` flag to prevent accidental execution with real funds.
+```typescript
+import { AgentClient } from "stellar-agentkit";
+
+const agent = new AgentClient({
+  network: "mainnet",
+  allowMainnet: true, // ⚠️ Required for mainnet
+});
+
+await agent.swap({
+  from: "USDC",
+  to: "XLM",
+  amount: "100",
+});
+```
+
+**Without the `allowMainnet` flag, you'll receive an error:**
+```
+🚫 Mainnet execution blocked for safety.
+Stellar AgentKit requires explicit opt-in for mainnet operations to prevent accidental use of real funds.
+To enable mainnet, set allowMainnet: true in your config.
+```
+
+---
+
+## Supported Networks
+
+- **Testnet** (full support) - No restrictions
+- **Mainnet** (requires `allowMainnet: true`) - Real transactions
+
+---

--- a/agent.ts
+++ b/agent.ts
@@ -11,6 +11,7 @@ export interface AgentConfig {
   network: "testnet" | "mainnet";
   rpcUrl?: string;
   publicKey?: string;
+  allowMainnet?: boolean; // 🆕 NEW: Add optional mainnet opt-in flag
 }
 
 export class AgentClient {
@@ -18,6 +19,25 @@ export class AgentClient {
   private publicKey: string;
 
   constructor(config: AgentConfig) {
+    // 🆕 NEW: Mainnet safety check - MUST come first
+    if (config.network === "mainnet" && !config.allowMainnet) {
+      throw new Error(
+        "🚫 Mainnet execution blocked for safety.\n" +
+        "Stellar AgentKit requires explicit opt-in for mainnet operations to prevent accidental use of real funds.\n" +
+        "To enable mainnet, set allowMainnet: true in your config:\n" +
+        "  new AgentClient({ network: 'mainnet', allowMainnet: true, ... })"
+      );
+    }
+
+    // 🆕 NEW: Warning for mainnet usage (even when opted in)
+    if (config.network === "mainnet" && config.allowMainnet) {
+      console.warn(
+        "\n⚠️  WARNING: STELLAR MAINNET ACTIVE ⚠️\n" +
+        "You are executing transactions on Stellar mainnet.\n" +
+        "Real funds will be used. Double-check all parameters before proceeding.\n"
+      );
+    }
+
     this.network = config.network;
     this.publicKey = config.publicKey || process.env.STELLAR_PUBLIC_KEY || "";
     


### PR DESCRIPTION
## 📌 Description
Implements mainnet safety guard to prevent accidental execution on production network.

## 🛠 Changes
- ✅ Added `allowMainnet?: boolean` flag to `AgentConfig` interface
- ✅ Throws error if `network: "mainnet"` without explicit `allowMainnet: true`
- ✅ Displays console warning when mainnet is properly enabled
- ✅ Updated documentation with safety notice and examples

## ✅ Acceptance Criteria Met
- [x] Mainnet cannot be used accidentally (requires explicit opt-in)
- [x] Clear error messages with instructions
- [x] No silent network switching
- [x] Console warning for mainnet execution

## 🧪 Testing
All safety checks verified and working as expected:
- ✅ Testnet works without restrictions
- ✅ Mainnet without flag throws clear error
- ✅ Mainnet with flag shows warning and works
- ✅ Error messages guide users to correct usage

## 📄 Files Changed
- `agent.ts` - Added mainnet safety guard logic
- `README.md` - Updated documentation with safety notice

Closes #4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mainnet safety guard that blocks execution unless allowMainnet: true is set. Prevents accidental use of real funds and shows a warning when mainnet is enabled.

- **New Features**
  - Added allowMainnet?: boolean to AgentConfig.
  - Throws an error if network is "mainnet" without allowMainnet.
  - Prints a console warning when mainnet is explicitly enabled.
  - Updated README with safety notice and examples.

- **Migration**
  - To run on mainnet, set allowMainnet: true in AgentClient config.
  - No changes needed for testnet.

<sup>Written for commit d3237167ed7c5fbfeb54c6092ffea2d2a188524d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

