### PR TITLE
🐛 fix: Improve Swap Error Messages with Contextual Debugging Info (Closes #3)

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -81,7 +81,7 @@ export class AgentClient {
   }, originalError: unknown): string {
     const originalMessage = originalError instanceof Error ? originalError.message : String(originalError);
     
-    // Mask sensitive parts of addresses for security
+    // Mask parts of addresses in logs for privacy/readability (addresses are public on-chain)
     const maskedRecipient = params.to.substring(0, 4) + "..." + params.to.substring(params.to.length - 4);
     
     return `Swap operation failed.

--- a/agent.ts
+++ b/agent.ts
@@ -66,7 +66,7 @@ export class AgentClient {
         params.inMax
       );
     } catch (error) {
-      throw new Error(this.formatSwapError(params, error));
+      throw new Error(this.formatSwapError(params, error), { cause: error as unknown });
     }
   }
 

--- a/agent.ts
+++ b/agent.ts
@@ -119,7 +119,7 @@ Reason: ${originalMessage}`;
       });
     } catch (error) {
       const originalMessage = error instanceof Error ? error.message : String(error);
-      const maskedAddress = params.toAddress.substring(0, 6) + "..." + params.toAddress.substring(params.toAddress.length - 4);
+      const maskedAddress = params.toAddress.substring(0, 4) + "..." + params.toAddress.substring(params.toAddress.length - 4);
       
       throw new Error(`Bridge operation failed.
 Network: ${this.network}

--- a/agent.ts
+++ b/agent.ts
@@ -57,13 +57,40 @@ export class AgentClient {
     out: string;
     inMax: string;
   }) {
-    return await contractSwap(
-      this.publicKey,
-      params.to,
-      params.buyA,
-      params.out,
-      params.inMax
-    );
+    try {
+      return await contractSwap(
+        this.publicKey,
+        params.to,
+        params.buyA,
+        params.out,
+        params.inMax
+      );
+    } catch (error) {
+      throw new Error(this.formatSwapError(params, error));
+    }
+  }
+
+  /**
+   * Private helper method to format swap error messages with context
+   */
+  private formatSwapError(params: {
+    to: string;
+    buyA: boolean;
+    out: string;
+    inMax: string;
+  }, originalError: unknown): string {
+    const originalMessage = originalError instanceof Error ? originalError.message : String(originalError);
+    
+    // Mask sensitive parts of addresses for security
+    const maskedRecipient = params.to.substring(0, 4) + "..." + params.to.substring(params.to.length - 4);
+    
+    return `Swap operation failed.
+Network: ${this.network}
+Recipient: ${maskedRecipient}
+Direction: buyA=${params.buyA}
+Requested Out: ${params.out}
+Max Input: ${params.inMax}
+Reason: ${originalMessage}`;
   }
 
   /**
@@ -82,13 +109,24 @@ export class AgentClient {
     amount: string;
     toAddress: string;
   }) {
-    return await bridgeTokenTool.func({
-      ...params,
-      fromNetwork:
-        this.network === "mainnet"
-          ? "stellar-mainnet"
-          : "stellar-testnet",
-    });
+    try {
+      return await bridgeTokenTool.func({
+        ...params,
+        fromNetwork:
+          this.network === "mainnet"
+            ? "stellar-mainnet"
+            : "stellar-testnet",
+      });
+    } catch (error) {
+      const originalMessage = error instanceof Error ? error.message : String(error);
+      const maskedAddress = params.toAddress.substring(0, 6) + "..." + params.toAddress.substring(params.toAddress.length - 4);
+      
+      throw new Error(`Bridge operation failed.
+Network: ${this.network}
+To Address: ${maskedAddress}
+Amount: ${params.amount}
+Reason: ${originalMessage}`);
+    }
   }
 
   /**
@@ -102,14 +140,28 @@ export class AgentClient {
       desiredB: string;
       minB: string;
     }) => {
-      return await contractDeposit(
-        this.publicKey,
-        params.to,
-        params.desiredA,
-        params.minA,
-        params.desiredB,
-        params.minB
-      );
+      try {
+        return await contractDeposit(
+          this.publicKey,
+          params.to,
+          params.desiredA,
+          params.minA,
+          params.desiredB,
+          params.minB
+        );
+      } catch (error) {
+        const originalMessage = error instanceof Error ? error.message : String(error);
+        const maskedRecipient = params.to.substring(0, 4) + "..." + params.to.substring(params.to.length - 4);
+        
+        throw new Error(`Liquidity deposit failed.
+Network: ${this.network}
+Recipient: ${maskedRecipient}
+Desired A: ${params.desiredA}
+Min A: ${params.minA}
+Desired B: ${params.desiredB}
+Min B: ${params.minB}
+Reason: ${originalMessage}`);
+      }
     },
 
     withdraw: async (params: {
@@ -118,21 +170,44 @@ export class AgentClient {
       minA: string;
       minB: string;
     }) => {
-      return await contractWithdraw(
-        this.publicKey,
-        params.to,
-        params.shareAmount,
-        params.minA,
-        params.minB
-      );
+      try {
+        return await contractWithdraw(
+          this.publicKey,
+          params.to,
+          params.shareAmount,
+          params.minA,
+          params.minB
+        );
+      } catch (error) {
+        const originalMessage = error instanceof Error ? error.message : String(error);
+        const maskedRecipient = params.to.substring(0, 4) + "..." + params.to.substring(params.to.length - 4);
+        
+        throw new Error(`Liquidity withdrawal failed.
+Network: ${this.network}
+Recipient: ${maskedRecipient}
+Share Amount: ${params.shareAmount}
+Min A: ${params.minA}
+Min B: ${params.minB}
+Reason: ${originalMessage}`);
+      }
     },
 
     getReserves: async () => {
-      return await contractGetReserves(this.publicKey);
+      try {
+        return await contractGetReserves(this.publicKey);
+      } catch (error) {
+        const originalMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to get reserves on ${this.network}. Reason: ${originalMessage}`);
+      }
     },
 
     getShareId: async () => {
-      return await contractGetShareId(this.publicKey);
+      try {
+        return await contractGetShareId(this.publicKey);
+      } catch (error) {
+        const originalMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to get share ID on ${this.network}. Reason: ${originalMessage}`);
+      }
     },
   };
 }


### PR DESCRIPTION
Closes #3

## 🐛 Improve Swap Error Messages

### 📌 Summary

This PR enhances error handling for failed swap operations by replacing generic error messages with descriptive, contextual debugging information.

Previously, swap failures returned unclear or generic errors, making debugging difficult for developers.

---

## ✅ Improvements Made

- Replaced generic swap error messages
- Included relevant swap parameters:
  - Network
  - Recipient address
  - Swap direction (buyA)
  - Requested output amount
  - Maximum input amount
- Preserved original error message from underlying failure
- Ensured no breaking API changes
- Maintained existing method signatures

---

## 🔐 Safety Considerations

- No sensitive information (secrets, private keys) is logged or exposed
- Only relevant debugging parameters are included
- Public method signatures remain unchanged

---

## 🧪 Testing

- Verified improved error output during failed swap scenarios
- Confirmed no impact on successful swap operations
- Build and existing tests pass successfully

---

## 📈 Impact

Improves developer experience by making swap-related failures easier to debug and diagnose without altering the SDK API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved swap, bridge, and liquidity error messages with contextual details and masked addresses to speed up debugging without changing the API. Closes #3.

- **Bug Fixes**
  - Swap: standardized multi-line errors via a private helper; includes network, masked recipient, buyA, out, inMax; preserves original reason.
  - Bridge: wraps tool errors with network, masked toAddress, and amount; preserves original reason.
  - Liquidity (deposit, withdraw, getReserves, getShareId): added try/catch with contextual messages (network, masked recipient where applicable, and amounts); method signatures and successful behavior unchanged.

<sup>Written for commit 4b1cc40bfa0ec5c5f39f18829fe759a83b969d07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

