### PR TITLE
feat: add transaction analytics and performance metrics

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -107,7 +107,7 @@ export class AgentClient {
         params.out,
         params.inMax
       );
-      finish({ success: true, inputAmount: params.inMax });
+      finish({ success: true, inputAmount: params.inMax, outputAmount: params.out });
       return result;
     } catch (err) {
       finish({ success: false, errorMessage: err instanceof Error ? err.message : String(err) });
@@ -159,14 +159,22 @@ export class AgentClient {
       desiredB: string;
       minB: string;
     }) => {
-      return await contractDeposit(
-        this.publicKey,
-        params.to,
-        params.desiredA,
-        params.minA,
-        params.desiredB,
-        params.minB
-      );
+      const finish = this.metrics.track("lp_deposit");
+      try {
+        const result = await contractDeposit(
+          this.publicKey,
+          params.to,
+          params.desiredA,
+          params.minA,
+          params.desiredB,
+          params.minB
+        );
+        finish({ success: true, inputAmount: params.desiredA });
+        return result;
+      } catch (err) {
+        finish({ success: false, errorMessage: err instanceof Error ? err.message : String(err) });
+        throw err;
+      }
     },
 
     withdraw: async (params: {
@@ -175,13 +183,21 @@ export class AgentClient {
       minA: string;
       minB: string;
     }) => {
-      return await contractWithdraw(
-        this.publicKey,
-        params.to,
-        params.shareAmount,
-        params.minA,
-        params.minB
-      );
+      const finish = this.metrics.track("lp_withdraw");
+      try {
+        const result = await contractWithdraw(
+          this.publicKey,
+          params.to,
+          params.shareAmount,
+          params.minA,
+          params.minB
+        );
+        finish({ success: true, inputAmount: params.shareAmount });
+        return result;
+      } catch (err) {
+        finish({ success: false, errorMessage: err instanceof Error ? err.message : String(err) });
+        throw err;
+      }
     },
 
     getReserves: async () => {

--- a/agent.ts
+++ b/agent.ts
@@ -1,3 +1,4 @@
+import { TransactionMetrics } from "./utils/metrics";
 import {
   swap as contractSwap,
   deposit as contractDeposit,
@@ -53,6 +54,7 @@ export class AgentClient {
   private network: "testnet" | "mainnet";
   private publicKey: string;
   private rpcUrl: string;
+  public readonly metrics: TransactionMetrics = new TransactionMetrics();
 
   constructor(config: AgentConfig) {
     // Mainnet safety check for general operations
@@ -96,13 +98,21 @@ export class AgentClient {
     out: string;
     inMax: string;
   }) {
-    return await contractSwap(
-      this.publicKey,
-      params.to,
-      params.buyA,
-      params.out,
-      params.inMax
-    );
+    const finish = this.metrics.track("swap");
+    try {
+      const result = await contractSwap(
+        this.publicKey,
+        params.to,
+        params.buyA,
+        params.out,
+        params.inMax
+      );
+      finish({ success: true, inputAmount: params.inMax });
+      return result;
+    } catch (err) {
+      finish({ success: false, errorMessage: err instanceof Error ? err.message : String(err) });
+      throw err;
+    }
   }
 
   /**
@@ -121,13 +131,21 @@ export class AgentClient {
     amount: string;
     toAddress: string;
   }) {
-    return await bridgeTokenTool.func({
-      ...params,
-      fromNetwork:
-        this.network === "mainnet"
-          ? "stellar-mainnet"
-          : "stellar-testnet",
-    });
+    const finish = this.metrics.track("bridge");
+    try {
+      const result = await bridgeTokenTool.func({
+        ...params,
+        fromNetwork:
+          this.network === "mainnet"
+            ? "stellar-mainnet"
+            : "stellar-testnet",
+      });
+      finish({ success: true, inputAmount: params.amount });
+      return result;
+    } catch (err) {
+      finish({ success: false, errorMessage: err instanceof Error ? err.message : String(err) });
+      throw err;
+    }
   }
 
   /**

--- a/tests/unit/utils/metrics.test.ts
+++ b/tests/unit/utils/metrics.test.ts
@@ -1,0 +1,120 @@
+import { TransactionMetrics } from "../../../utils/metrics";
+
+describe("TransactionMetrics", () => {
+  let metrics: TransactionMetrics;
+
+  beforeEach(() => {
+    metrics = new TransactionMetrics();
+  });
+
+  describe("track", () => {
+    it("records a successful swap", () => {
+      const finish = metrics.track("swap");
+      finish({ success: true, inputAmount: "100", outputAmount: "95", slippagePct: 5 });
+      expect(metrics.history()).toHaveLength(1);
+      expect(metrics.history()[0].type).toBe("swap");
+      expect(metrics.history()[0].success).toBe(true);
+    });
+
+    it("records a failed bridge", () => {
+      const finish = metrics.track("bridge");
+      finish({ success: false, errorMessage: "Timeout" });
+      expect(metrics.history()[0].success).toBe(false);
+      expect(metrics.history()[0].errorMessage).toBe("Timeout");
+    });
+
+    it("records duration", async () => {
+      const finish = metrics.track("swap");
+      await new Promise((r) => setTimeout(r, 10));
+      const record = finish({ success: true });
+      expect(record.durationMs).toBeGreaterThanOrEqual(10);
+    });
+
+    it("assigns unique IDs", () => {
+      const f1 = metrics.track("swap");
+      const f2 = metrics.track("swap");
+      const r1 = f1({ success: true });
+      const r2 = f2({ success: true });
+      expect(r1.id).not.toBe(r2.id);
+    });
+  });
+
+  describe("summary", () => {
+    it("returns zeroed summary when no records", () => {
+      const s = metrics.summary();
+      expect(s.totalTransactions).toBe(0);
+      expect(s.successRate).toBe("0.00%");
+      expect(s.totalVolume).toBe("0.0000000");
+    });
+
+    it("calculates success rate correctly", () => {
+      const f1 = metrics.track("swap");
+      f1({ success: true, inputAmount: "100" });
+      const f2 = metrics.track("swap");
+      f2({ success: false });
+      const s = metrics.summary();
+      expect(s.successCount).toBe(1);
+      expect(s.failureCount).toBe(1);
+      expect(s.successRate).toBe("50.00%");
+    });
+
+    it("calculates total volume from inputAmount", () => {
+      const f1 = metrics.track("swap");
+      f1({ success: true, inputAmount: "100" });
+      const f2 = metrics.track("lp_deposit");
+      f2({ success: true, inputAmount: "200" });
+      expect(metrics.summary().totalVolume).toBe("300.0000000");
+    });
+
+    it("calculates avgSlippage only from successful records", () => {
+      const f1 = metrics.track("swap");
+      f1({ success: true, slippagePct: 1.0 });
+      const f2 = metrics.track("swap");
+      f2({ success: true, slippagePct: 3.0 });
+      const f3 = metrics.track("swap");
+      f3({ success: false, slippagePct: 99.0 }); // should be excluded
+      expect(metrics.summary().avgSlippage).toBe("2.00%");
+    });
+
+    it("counts byType correctly", () => {
+      metrics.track("swap")({ success: true });
+      metrics.track("swap")({ success: false });
+      metrics.track("bridge")({ success: true });
+      const s = metrics.summary();
+      expect(s.byType.swap.count).toBe(2);
+      expect(s.byType.swap.successCount).toBe(1);
+      expect(s.byType.bridge.count).toBe(1);
+      expect(s.byType.lp_deposit.count).toBe(0);
+    });
+  });
+
+  describe("byType", () => {
+    it("filters records by operation type", () => {
+      metrics.track("swap")({ success: true });
+      metrics.track("bridge")({ success: true });
+      metrics.track("swap")({ success: false });
+      expect(metrics.byType("swap")).toHaveLength(2);
+      expect(metrics.byType("bridge")).toHaveLength(1);
+      expect(metrics.byType("lp_withdraw")).toHaveLength(0);
+    });
+  });
+
+  describe("recent", () => {
+    it("returns last N records", () => {
+      for (let i = 0; i < 15; i++) {
+        metrics.track("swap")({ success: true, inputAmount: String(i) });
+      }
+      expect(metrics.recent(5)).toHaveLength(5);
+      expect(metrics.recent(5)[4].inputAmount).toBe("14");
+    });
+  });
+
+  describe("clear", () => {
+    it("resets all records and counter", () => {
+      metrics.track("swap")({ success: true });
+      metrics.clear();
+      expect(metrics.history()).toHaveLength(0);
+      expect(metrics.summary().totalTransactions).toBe(0);
+    });
+  });
+});

--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -43,8 +43,14 @@ export class TransactionMetrics {
   track(type: OperationType): (result: Omit<TransactionRecord, "id" | "type" | "timestamp" | "durationMs">) => TransactionRecord {
     const id = `${type}-${++this.idCounter}-${Date.now()}`;
     const startTime = Date.now();
+    let finished = false;
 
     return (result) => {
+      if (finished) {
+        // Return the already-recorded entry to stay idempotent
+        return this.records.find((r) => r.id === id)!;
+      }
+      finished = true;
       const record: TransactionRecord = {
         id,
         type,
@@ -74,9 +80,14 @@ export class TransactionMetrics {
     const successful = this.records.filter((r) => r.success);
     const failed = this.records.filter((r) => !r.success);
 
+    const toNumber = (s: string | undefined): number => {
+      if (!s) return 0;
+      const n = parseFloat(s);
+      return Number.isFinite(n) ? n : 0;
+    };
     const totalVolume = this.records
       .filter((r) => r.inputAmount)
-      .reduce((acc, r) => acc + parseFloat(r.inputAmount!), 0);
+      .reduce((acc, r) => acc + toNumber(r.inputAmount), 0);
 
     const slippageRecords = this.records.filter(
       (r) => r.slippagePct !== undefined && r.success

--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -1,0 +1,149 @@
+/**
+ * Transaction Analytics and Performance Metrics
+ * Addresses issue #38
+ *
+ * Tracks swap, bridge, and LP operations in-memory and exposes
+ * a metrics API via AgentClient.metrics.*
+ */
+
+export type OperationType = "swap" | "bridge" | "lp_deposit" | "lp_withdraw";
+
+export interface TransactionRecord {
+  id: string;
+  type: OperationType;
+  timestamp: number;
+  success: boolean;
+  durationMs: number;
+  inputAmount?: string;
+  outputAmount?: string;
+  slippagePct?: number;
+  errorMessage?: string;
+}
+
+export interface MetricsSummary {
+  totalTransactions: number;
+  successCount: number;
+  failureCount: number;
+  successRate: string;
+  totalVolume: string;
+  avgDurationMs: number;
+  avgSlippage: string;
+  byType: Record<OperationType, { count: number; successCount: number }>;
+}
+
+export class TransactionMetrics {
+  private records: TransactionRecord[] = [];
+  private idCounter = 0;
+
+  /**
+   * Start timing a new transaction. Returns a finisher function.
+   * Call finisher({ success, inputAmount, outputAmount, slippagePct, errorMessage })
+   * when the operation completes.
+   */
+  track(type: OperationType): (result: Omit<TransactionRecord, "id" | "type" | "timestamp" | "durationMs">) => TransactionRecord {
+    const id = `${type}-${++this.idCounter}-${Date.now()}`;
+    const startTime = Date.now();
+
+    return (result) => {
+      const record: TransactionRecord = {
+        id,
+        type,
+        timestamp: startTime,
+        durationMs: Date.now() - startTime,
+        ...result,
+      };
+      this.records.push(record);
+      return record;
+    };
+  }
+
+  /**
+   * Returns aggregated performance metrics across all tracked operations.
+   *
+   * @example
+   * const summary = agent.metrics.summary();
+   * // {
+   * //   totalTransactions: 10,
+   * //   successRate: "90.00%",
+   * //   totalVolume: "10000.0000000",
+   * //   avgSlippage: "1.20%",
+   * //   ...
+   * // }
+   */
+  summary(): MetricsSummary {
+    const successful = this.records.filter((r) => r.success);
+    const failed = this.records.filter((r) => !r.success);
+
+    const totalVolume = this.records
+      .filter((r) => r.inputAmount)
+      .reduce((acc, r) => acc + parseFloat(r.inputAmount!), 0);
+
+    const slippageRecords = this.records.filter(
+      (r) => r.slippagePct !== undefined && r.success
+    );
+    const avgSlippage =
+      slippageRecords.length > 0
+        ? slippageRecords.reduce((acc, r) => acc + r.slippagePct!, 0) /
+          slippageRecords.length
+        : 0;
+
+    const avgDurationMs =
+      this.records.length > 0
+        ? this.records.reduce((acc, r) => acc + r.durationMs, 0) /
+          this.records.length
+        : 0;
+
+    const byType = {} as Record<OperationType, { count: number; successCount: number }>;
+    for (const type of ["swap", "bridge", "lp_deposit", "lp_withdraw"] as OperationType[]) {
+      const typeRecords = this.records.filter((r) => r.type === type);
+      byType[type] = {
+        count: typeRecords.length,
+        successCount: typeRecords.filter((r) => r.success).length,
+      };
+    }
+
+    return {
+      totalTransactions: this.records.length,
+      successCount: successful.length,
+      failureCount: failed.length,
+      successRate:
+        this.records.length > 0
+          ? `${((successful.length / this.records.length) * 100).toFixed(2)}%`
+          : "0.00%",
+      totalVolume: totalVolume.toFixed(7),
+      avgDurationMs: Math.round(avgDurationMs),
+      avgSlippage: `${avgSlippage.toFixed(2)}%`,
+      byType,
+    };
+  }
+
+  /**
+   * Returns the raw list of transaction records.
+   * Useful for debugging or building custom dashboards.
+   */
+  history(): TransactionRecord[] {
+    return [...this.records];
+  }
+
+  /**
+   * Returns records filtered by operation type.
+   */
+  byType(type: OperationType): TransactionRecord[] {
+    return this.records.filter((r) => r.type === type);
+  }
+
+  /**
+   * Returns the last N transactions.
+   */
+  recent(n = 10): TransactionRecord[] {
+    return this.records.slice(-n);
+  }
+
+  /**
+   * Clears all tracked records.
+   */
+  clear(): void {
+    this.records = [];
+    this.idCounter = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #38

Adds a `TransactionMetrics` class and wires it into `AgentClient` as `agent.metrics.*`. Previously swap, bridge, and LP operations executed blindly with no tracking, debugging visibility, or performance insights.

## What was added

### `utils/metrics.ts` (new file)
`TransactionMetrics` class with full in-memory tracking:
- `track(type)` — starts a timer, returns a finisher called on completion with `{ success, inputAmount, outputAmount, slippagePct, errorMessage }`
- `summary()` — aggregated metrics across all operations
- `history()` — raw `TransactionRecord[]` for custom dashboards
- `byType(type)` — filter by `swap | bridge | lp_deposit | lp_withdraw`
- `recent(n)` — last N transactions (default 10)
- `clear()` — reset all records

**Example output of `agent.metrics.summary()`:**
```ts
{
  totalTransactions: 10,
  successCount: 9,
  failureCount: 1,
  successRate: "90.00%",
  totalVolume: "10000.0000000",
  avgDurationMs: 342,
  avgSlippage: "1.20%",
  byType: {
    swap: { count: 7, successCount: 7 },
    bridge: { count: 2, successCount: 1 },
    lp_deposit: { count: 1, successCount: 1 },
    lp_withdraw: { count: 0, successCount: 0 }
  }
}
```

### `agent.ts`
- Added `public readonly metrics: TransactionMetrics` property
- Wrapped `swap()` with metrics tracking (success/failure + inputAmount)
- Wrapped `bridge()` with metrics tracking (success/failure + inputAmount)

### `tests/unit/utils/metrics.test.ts` (new file)
12 tests covering all public methods — track, summary, byType, recent, clear.

## Results
```
Tests: 12 passed (0 failed)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-memory transaction analytics to `AgentClient` so swaps, bridges, and LP actions record duration, success, volume, slippage, and outputs. Addresses #38 with a `metrics` API for summaries and history.

- **New Features**
  - New `utils/metrics.ts`: `TransactionMetrics` with `track` (idempotent), `summary` (NaN-safe volume), `history`, `byType`, `recent`, `clear` for `swap | bridge | lp_deposit | lp_withdraw`.
  - `AgentClient`: exposes `metrics`; wraps `swap()`, `bridge()`, `lp.deposit()`, and `lp.withdraw()` to record success/failure, duration, input/output amounts, and errors.
  - 12 unit tests covering all public metrics methods and aggregations.

<sup>Written for commit 992ebc3aaa994a7aa2bb9e54e7aa430fe4293095. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

