### PR TITLE
feat: add Stellar balance check tools

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -6,6 +6,7 @@ import {
   getShareId as contractGetShareId,
 } from "./lib/contract";
 import { bridgeTokenTool } from "./tools/bridge";
+import { stellarGetBalanceTool, stellarGetAllBalancesTool } from "./tools/balance";
 import {
   Server,
   Keypair,
@@ -128,6 +129,26 @@ export class AgentClient {
           ? "stellar-mainnet"
           : "stellar-testnet",
     });
+  }
+
+  /**
+   * Get the balance of an account for XLM or a specific asset.
+   * @param params Balance parameters
+   */
+  async getBalance(params: {
+    address: string;
+    assetCode?: string;
+    assetIssuer?: string;
+  }) {
+    return await stellarGetBalanceTool.func(params);
+  }
+
+  /**
+   * Get all asset balances for an account.
+   * @param address The Stellar public key
+   */
+  async getAllBalances(address: string) {
+    return await stellarGetAllBalancesTool.func({ address });
   }
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import { bridgeTokenTool } from "./tools/bridge";
 import { StellarLiquidityContractTool } from "./tools/contract";
 import { StellarContractTool } from "./tools/stake";
 import { stellarSendPaymentTool } from "./tools/stellar";
+import { stellarGetBalanceTool, stellarGetAllBalancesTool } from "./tools/balance";
 import { 
   AgentClient, 
   AgentConfig,
@@ -19,5 +20,7 @@ export const stellarTools = [
   bridgeTokenTool,
   StellarLiquidityContractTool,
   StellarContractTool,
-  stellarSendPaymentTool
+  stellarSendPaymentTool,
+  stellarGetBalanceTool,
+  stellarGetAllBalancesTool
 ];

--- a/tests/unit/tools/balance.test.ts
+++ b/tests/unit/tools/balance.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { stellarGetBalanceTool, stellarGetAllBalancesTool } from '../../../tools/balance';
+import { StrKey } from '@stellar/stellar-sdk';
+
+// Mock Stellar SDK
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const original = await importOriginal<any>();
+  return {
+    ...original,
+    Horizon: {
+      Server: vi.fn().mockImplementation(() => ({
+        loadAccount: vi.fn().mockResolvedValue({
+          balances: [
+            { asset_type: 'native', balance: '100.0000000' },
+            { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GABC...', balance: '50.0000000' }
+          ]
+        })
+      }))
+    },
+    StrKey: {
+      isValidEd25519PublicKey: vi.fn().mockImplementation((addr) => addr.startsWith('G'))
+    }
+  };
+});
+
+describe('Balance Tools', () => {
+  describe('stellar_get_balance', () => {
+    it('should return native XLM balance by default', async () => {
+      const result = await stellarGetBalanceTool.func({ address: 'GDRAW...' });
+      expect(result).toBe('Balance: 100.0000000 XLM');
+    });
+
+    it('should return specific asset balance', async () => {
+      const result = await stellarGetBalanceTool.func({ 
+        address: 'GDRAW...', 
+        assetCode: 'USDC', 
+        assetIssuer: 'GABC...' 
+      });
+      expect(result).toBe('Balance: 50.0000000 USDC (GABC...)');
+    });
+
+    it('should return 0 for non-existent asset', async () => {
+      const result = await stellarGetBalanceTool.func({ 
+        address: 'GDRAW...', 
+        assetCode: 'EURT', 
+        assetIssuer: 'GXYZ...' 
+      });
+      expect(result).toBe('Balance: 0 EURT (GXYZ...)');
+    });
+
+    it('should validate address', async () => {
+      const result = await stellarGetBalanceTool.func({ address: 'INVALID' });
+      expect(result).toContain('Invalid Stellar address');
+    });
+  });
+
+  describe('stellar_get_all_balances', () => {
+    it('should return all balances formatted', async () => {
+      const result = await stellarGetAllBalancesTool.func({ address: 'GDRAW...' });
+      expect(result).toContain('XLM: 100.0000000');
+      expect(result).toContain('USDC (GABC...): 50.0000000');
+    });
+  });
+});

--- a/tools/balance.ts
+++ b/tools/balance.ts
@@ -1,0 +1,87 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { Horizon, StrKey } from "@stellar/stellar-sdk";
+
+export const stellarGetBalanceTool = new DynamicStructuredTool({
+  name: "stellar_get_balance",
+  description: "Get the balance of a Stellar account for XLM or a specific asset.",
+  schema: z.object({
+    address: z.string().describe("The Stellar public key (G...) to check balance for"),
+    assetCode: z.string().optional().describe("The asset code (e.g., 'USDC', 'XLM'). Defaults to 'XLM'."),
+    assetIssuer: z.string().optional().describe("The asset issuer address. Required for non-XLM assets (except if it is a well-known asset code, but recommended to provide)."),
+  }),
+  func: async ({ address, assetCode = "XLM", assetIssuer }: { address: string; assetCode?: string; assetIssuer?: string }) => {
+    try {
+      if (!StrKey.isValidEd25519PublicKey(address)) {
+        throw new Error("Invalid Stellar address.");
+      }
+
+      const network = typeof process !== 'undefined' ? process.env.STELLAR_NETWORK || "testnet" : "testnet";
+      const horizonUrl = network === "mainnet" 
+        ? "https://horizon.stellar.org" 
+        : "https://horizon-testnet.stellar.org";
+      
+      const server = new Horizon.Server(horizonUrl);
+      const account = await server.loadAccount(address);
+
+      const balances = account.balances;
+      
+      if (assetCode.toUpperCase() === "XLM") {
+        const nativeBalance = balances.find((b: Horizon.BalanceLine) => b.asset_type === "native");
+        return nativeBalance ? `Balance: ${nativeBalance.balance} XLM` : "Balance: 0 XLM";
+      }
+
+      const assetBalance = balances.find((b: Horizon.BalanceLine) => {
+        if (b.asset_type === "native") return false;
+        return b.asset_code === assetCode && (!assetIssuer || b.asset_issuer === assetIssuer);
+      });
+
+      if (!assetBalance) {
+        return `Balance: 0 ${assetCode}${assetIssuer ? ` (${assetIssuer})` : ""}`;
+      }
+
+      return `Balance: ${assetBalance.balance} ${assetCode}${assetIssuer ? ` (${assetIssuer})` : ""}`;
+    } catch (error: any) {
+      return `Failed to fetch balance: ${error.message}`;
+    }
+  },
+});
+
+export const stellarGetAllBalancesTool = new DynamicStructuredTool({
+  name: "stellar_get_all_balances",
+  description: "Get all asset balances for a Stellar account.",
+  schema: z.object({
+    address: z.string().describe("The Stellar public key (G...) to check balances for"),
+  }),
+  func: async ({ address }: { address: string }) => {
+    try {
+      if (!StrKey.isValidEd25519PublicKey(address)) {
+        throw new Error("Invalid Stellar address.");
+      }
+
+      const network = typeof process !== 'undefined' ? process.env.STELLAR_NETWORK || "testnet" : "testnet";
+      const horizonUrl = network === "mainnet" 
+        ? "https://horizon.stellar.org" 
+        : "https://horizon-testnet.stellar.org";
+      
+      const server = new Horizon.Server(horizonUrl);
+      const account = await server.loadAccount(address);
+
+      const balances = account.balances.map((b: Horizon.BalanceLine) => {
+        if (b.asset_type === "native") {
+          return `XLM: ${b.balance}`;
+        }
+        return `${(b as Horizon.BalanceLineAsset).asset_code} (${(b as Horizon.BalanceLineAsset).asset_issuer}): ${b.balance}`;
+      });
+
+      if (balances.length === 0) {
+        return "No balances found for this account.";
+      }
+
+      return `Balances for ${address}:\n${balances.join("\n")}`;
+    } catch (error: any) {
+      return `Failed to fetch balances: ${error.message}`;
+    }
+  },
+});
+


### PR DESCRIPTION
## Description
This PR adds new tools for checking Stellar account balances directly through the SDK and AgentClient.

### Changes
- Added : A tool to fetch the balance of a specific account for a given asset (defaults to XLM).
- Added : A tool to retrieve all asset balances for an account.
- Exported new tools in  array in .
- Added  and  methods to  class in  for consistent developer experience.
- Added comprehensive unit tests in  (mocking Stellar SDK for testability).

### Impact
This allows developers and AI agents to verify account state before and after DeFi operations without needing to implement their own balance logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two Stellar balance tools and AgentClient wrappers to fetch XLM/specified asset balances or list all balances, making it easy to verify account state around DeFi operations.

- **New Features**
  - New tools: `stellar_get_balance` and `stellar_get_all_balances` (XLM and credit assets; address validation; uses `STELLAR_NETWORK` with testnet default).
  - Exported in `stellarTools` via `index.ts`.
  - AgentClient: `getBalance({ address, assetCode?, assetIssuer? })` and `getAllBalances(address)`.
  - Unit tests added with mocked `@stellar/stellar-sdk`.

<sup>Written for commit 1da005982a924435549049c4ba56e9f55b4a6675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

