### PR TITLE
feat(payments): add Stellar payment flow and safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ multiple operations into a single programmable and extensible toolkit.
 ## ✨ Features
 
 - Token swaps on Stellar
+- Native XLM and issued-asset payments
 - Cross-chain bridging
 - Liquidity pool (LP) deposits & withdrawals
 - Querying pool reserves and share IDs
@@ -170,6 +171,39 @@ await agent.swap({
 This older `agent.swap()` method is a direct Soroban contract call against a
 single configured pool. It is separate from `agent.dex.*` and should not be
 treated as the best-route swap API.
+
+---
+
+## 💸 Send Payments
+
+`agent.sendPayment()` sends either native XLM or issued assets on Stellar
+Classic using the configured Horizon network.
+
+Highlights:
+
+- Supports optional text memos
+- Uses the configured `STELLAR_PRIVATE_KEY` only when it matches the source account
+- Automatically falls back to `createAccount` when funding an unfunded address with native XLM
+- Validates destination trustlines before issued-asset payments
+
+```typescript
+const payment = await agent.sendPayment({
+  destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+  amount: "25.0000000",
+  memo: "invoice-42"
+});
+
+const usdcPayment = await agent.sendPayment({
+  destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+  amount: "10.5000000",
+  asset: {
+    code: "USDC",
+    issuer: "G..."
+  }
+});
+```
+
+The `stellar_send_payment` tool exposes the same flow for agent/tooling use.
 
 ---
 

--- a/agent.ts
+++ b/agent.ts
@@ -8,13 +8,18 @@ import {
 import {
   quoteSwap as quoteDexSwap,
   swapBestRoute as executeBestRouteSwap,
-  type StellarAssetInput,
   type QuoteSwapParams,
   type RouteQuote,
   type SwapBestRouteParams,
   type SwapBestRouteResult,
 } from "./lib/dex";
-import { bridgeTokenTool } from "./tools/bridge";
+import {
+  sendPayment as executePayment,
+  type SendPaymentParams,
+  type SendPaymentResult,
+} from "./lib/payments";
+import type { StellarAssetInput } from "./lib/assets";
+import { bridgeTokenTool, type TargetChain } from "./tools/bridge";
 import {
   Horizon,
   Keypair,
@@ -66,6 +71,8 @@ export type {
   RouteQuote,
   SwapBestRouteParams,
   SwapBestRouteResult,
+  SendPaymentParams,
+  SendPaymentResult,
 };
 
 export class AgentClient {
@@ -231,6 +238,23 @@ export class AgentClient {
       );
     },
   };
+
+  /**
+   * Send native XLM or issued-asset payments on Stellar Classic.
+   *
+   * Native payments automatically fall back to `createAccount` when the destination
+   * does not exist yet, which is useful for first-time account funding flows.
+   */
+  async sendPayment(params: SendPaymentParams): Promise<SendPaymentResult> {
+    return await executePayment(
+      {
+        network: this.network,
+        horizonUrl: this.rpcUrl,
+        publicKey: this.publicKey,
+      },
+      params
+    );
+  }
 
   /**
    * Launch a new token on the Stellar network.

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,8 @@ import {
   AgentConfig,
   LaunchTokenParams,
   LaunchTokenResult,
+  SendPaymentParams,
+  SendPaymentResult,
 } from "./agent";
 import type {
   StellarAssetInput,
@@ -22,6 +24,8 @@ export {
   AgentConfig,
   LaunchTokenParams,
   LaunchTokenResult,
+  SendPaymentParams,
+  SendPaymentResult,
 };
 
 export type {

--- a/lib/assets.ts
+++ b/lib/assets.ts
@@ -1,0 +1,31 @@
+import { Asset, StrKey } from "@stellar/stellar-sdk";
+
+export type StellarAssetInput =
+  | { type: "native" }
+  | { code: string; issuer: string };
+
+export function isNativeAssetInput(
+  asset: StellarAssetInput
+): asset is { type: "native" } {
+  return "type" in asset;
+}
+
+export function assetInputToSdkAsset(asset: StellarAssetInput): Asset {
+  if (isNativeAssetInput(asset)) {
+    return Asset.native();
+  }
+
+  if (!asset.code || !asset.issuer) {
+    throw new Error("Issued assets require both code and issuer");
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(asset.issuer)) {
+    throw new Error(`Invalid issuer public key: ${asset.issuer}`);
+  }
+
+  return new Asset(asset.code, asset.issuer);
+}
+
+export function assetInputToHorizonAsset(asset: StellarAssetInput): string {
+  return isNativeAssetInput(asset) ? "native" : `${asset.code}:${asset.issuer}`;
+}

--- a/lib/assets.ts
+++ b/lib/assets.ts
@@ -7,7 +7,12 @@ export type StellarAssetInput =
 export function isNativeAssetInput(
   asset: StellarAssetInput
 ): asset is { type: "native" } {
-  return "type" in asset;
+  return (
+    typeof asset === "object" &&
+    asset !== null &&
+    "type" in asset &&
+    asset.type === "native"
+  );
 }
 
 export function assetInputToSdkAsset(asset: StellarAssetInput): Asset {

--- a/lib/dex.ts
+++ b/lib/dex.ts
@@ -1,17 +1,17 @@
 import Big from "big.js";
 import {
-  Asset,
   Horizon,
   Networks,
   StrKey,
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
+import {
+  assetInputToHorizonAsset,
+  assetInputToSdkAsset,
+  type StellarAssetInput,
+} from "./assets";
 import { getSigningKeypair, signTransaction } from "./stellar";
 import { buildPathPaymentTransaction } from "../utils/buildTransaction";
-
-export type StellarAssetInput =
-  | { type: "native" }
-  | { code: string; issuer: string };
 
 export type RouteMode = "strict-send" | "strict-receive";
 
@@ -97,25 +97,7 @@ const DEFAULT_LIMIT = 5;
 const DEFAULT_SLIPPAGE_BPS = 100;
 const INTERNAL_FETCH_LIMIT = 20;
 
-export function assetInputToSdkAsset(asset: StellarAssetInput): Asset {
-  if ("type" in asset) {
-    return Asset.native();
-  }
-
-  if (!asset.code || !asset.issuer) {
-    throw new Error("Issued assets require both code and issuer");
-  }
-
-  if (!StrKey.isValidEd25519PublicKey(asset.issuer)) {
-    throw new Error(`Invalid issuer public key: ${asset.issuer}`);
-  }
-
-  return new Asset(asset.code, asset.issuer);
-}
-
-export function assetInputToHorizonAsset(asset: StellarAssetInput): string {
-  return "type" in asset ? "native" : `${asset.code}:${asset.issuer}`;
-}
+export { assetInputToHorizonAsset, assetInputToSdkAsset } from "./assets";
 
 export function normalizePathRecord(record: HorizonPathRecord): RouteQuote {
   const path = record.path.map(horizonAssetToInput);

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,231 @@
+import Big from "big.js";
+import {
+  BASE_FEE,
+  Horizon,
+  Memo,
+  Networks,
+  Operation,
+  StrKey,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import {
+  assetInputToSdkAsset,
+  isNativeAssetInput,
+  type StellarAssetInput,
+} from "./assets";
+import { getSigningKeypair, signTransaction } from "./stellar";
+
+export interface PaymentClientConfig {
+  network: "testnet" | "mainnet";
+  horizonUrl: string;
+  publicKey: string;
+}
+
+export interface SendPaymentParams {
+  destination: string;
+  amount: string;
+  asset?: StellarAssetInput;
+  memo?: string;
+}
+
+export interface SendPaymentResult {
+  hash: string;
+  network: PaymentClientConfig["network"];
+  operation: "payment" | "create-account";
+  destination: string;
+  amount: string;
+  asset: StellarAssetInput;
+  memo?: string;
+}
+
+interface PaymentDependencies {
+  createServer?: (horizonUrl: string) => {
+    loadAccount: (publicKey: string) => Promise<any>;
+    submitTransaction: (transaction: any) => Promise<{ hash: string }>;
+  };
+}
+
+interface PaymentBalanceLine {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+interface DestinationAccountLike {
+  balances?: PaymentBalanceLine[];
+}
+
+const DEFAULT_PAYMENT_ASSET: StellarAssetInput = { type: "native" };
+const MAX_MEMO_BYTES = 28;
+
+export async function sendPayment(
+  client: PaymentClientConfig,
+  params: SendPaymentParams,
+  deps: PaymentDependencies = {}
+): Promise<SendPaymentResult> {
+  validatePublicKey(client.publicKey, "publicKey");
+  validatePublicKey(params.destination, "destination");
+  validateAmount(params.amount);
+  validateMemo(params.memo);
+
+  const asset = params.asset ?? DEFAULT_PAYMENT_ASSET;
+  const sdkAsset = assetInputToSdkAsset(asset);
+
+  getSigningKeypair(client.publicKey);
+
+  const createServer =
+    deps.createServer ?? ((horizonUrl: string) => new Horizon.Server(horizonUrl));
+  const server = createServer(client.horizonUrl);
+  const sourceAccount = await server.loadAccount(client.publicKey);
+
+  const destinationAccount = await tryLoadAccount(server, params.destination);
+  const operation = resolvePaymentOperation(asset, params.destination, destinationAccount);
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(client.network),
+    memo: params.memo ? Memo.text(params.memo) : undefined,
+  });
+
+  if (operation === "create-account") {
+    transaction.addOperation(
+      Operation.createAccount({
+        destination: params.destination,
+        startingBalance: params.amount,
+      })
+    );
+  } else {
+    transaction.addOperation(
+      Operation.payment({
+        destination: params.destination,
+        asset: sdkAsset,
+        amount: params.amount,
+      })
+    );
+  }
+
+  transaction.setTimeout(300);
+
+  const signedXdr = signTransaction(
+    transaction.build().toXDR(),
+    getNetworkPassphrase(client.network),
+    client.publicKey
+  );
+  const signedTransaction = TransactionBuilder.fromXDR(
+    signedXdr,
+    getNetworkPassphrase(client.network)
+  );
+
+  const submission = await server.submitTransaction(signedTransaction);
+
+  return {
+    hash: submission.hash,
+    network: client.network,
+    operation,
+    destination: params.destination,
+    amount: params.amount,
+    asset,
+    memo: params.memo,
+  };
+}
+
+function resolvePaymentOperation(
+  asset: StellarAssetInput,
+  destination: string,
+  destinationAccount: DestinationAccountLike | null
+): "payment" | "create-account" {
+  if (!destinationAccount) {
+    if (!isNativeAssetInput(asset)) {
+      throw new Error(
+        "Destination account does not exist. Issued-asset payments require an existing destination trustline."
+      );
+    }
+
+    return "create-account";
+  }
+
+  if (
+    !isNativeAssetInput(asset) &&
+    destination !== asset.issuer &&
+    !accountSupportsAsset(destinationAccount, asset)
+  ) {
+    throw new Error("Destination account does not trust the requested asset");
+  }
+
+  return "payment";
+}
+
+function accountSupportsAsset(
+  account: DestinationAccountLike,
+  asset: Exclude<StellarAssetInput, { type: "native" }>
+): boolean {
+  return (account.balances ?? []).some((balance) => {
+    return (
+      balance.asset_type !== "native" &&
+      balance.asset_type !== "liquidity_pool_shares" &&
+      balance.asset_code === asset.code &&
+      balance.asset_issuer === asset.issuer
+    );
+  });
+}
+
+async function tryLoadAccount(
+  server: {
+    loadAccount: (publicKey: string) => Promise<any>;
+  },
+  publicKey: string
+): Promise<DestinationAccountLike | null> {
+  try {
+    return await server.loadAccount(publicKey);
+  } catch (error) {
+    if (isAccountNotFoundError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function isAccountNotFoundError(error: unknown): boolean {
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  return status === 404;
+}
+
+function validateAmount(amount: string) {
+  try {
+    const parsed = new Big(amount);
+    if (parsed.lte(0)) {
+      throw new Error("Amount must be greater than 0");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === "Amount must be greater than 0") {
+      throw error;
+    }
+
+    throw new Error("Amount must be a valid positive Stellar amount");
+  }
+
+  const [, decimals] = amount.split(".");
+  if (decimals && decimals.length > 7) {
+    throw new Error("Amount cannot have more than 7 decimal places");
+  }
+}
+
+function validateMemo(memo?: string) {
+  if (!memo) {
+    return;
+  }
+
+  if (Buffer.byteLength(memo, "utf8") > MAX_MEMO_BYTES) {
+    throw new Error("Memo must be 28 bytes or fewer");
+  }
+}
+
+function validatePublicKey(value: string, label: string) {
+  if (!value || !StrKey.isValidEd25519PublicKey(value)) {
+    throw new Error(`Invalid ${label} Stellar public key`);
+  }
+}
+
+function getNetworkPassphrase(network: PaymentClientConfig["network"]): string {
+  return network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}

--- a/tests/unit/lib/assets.test.ts
+++ b/tests/unit/lib/assets.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import { assetInputToSdkAsset, isNativeAssetInput } from "../../../lib/assets";
+
+describe("asset helpers", () => {
+  const issuer = Keypair.random().publicKey();
+
+  it("recognizes only an explicit native discriminator", () => {
+    expect(isNativeAssetInput({ type: "native" })).toBe(true);
+    expect(
+      isNativeAssetInput({ type: "credit_alphanum4", code: "USD", issuer } as never)
+    ).toBe(false);
+    expect(isNativeAssetInput({ code: "USD", issuer } as never)).toBe(false);
+  });
+
+  it("does not misclassify malformed issued assets as native", () => {
+    expect(() =>
+      assetInputToSdkAsset({ type: "credit_alphanum4" } as never)
+    ).toThrow("Issued assets require both code and issuer");
+  });
+});

--- a/tests/unit/lib/payments.test.ts
+++ b/tests/unit/lib/payments.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Account, Keypair } from "@stellar/stellar-sdk";
+import { sendPayment } from "../../../lib/payments";
+
+describe("sendPayment", () => {
+  const originalSecret = process.env.STELLAR_PRIVATE_KEY;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    if (originalSecret === undefined) {
+      delete process.env.STELLAR_PRIVATE_KEY;
+      return;
+    }
+
+    process.env.STELLAR_PRIVATE_KEY = originalSecret;
+  });
+
+  it("submits a standard native payment to an existing destination", async () => {
+    const signer = Keypair.random();
+    const destination = Keypair.random().publicKey();
+    process.env.STELLAR_PRIVATE_KEY = signer.secret();
+
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: "payment-hash" });
+    const loadAccount = vi.fn(async (publicKey: string) => {
+      if (publicKey === signer.publicKey()) {
+        return new Account(publicKey, "123");
+      }
+
+      return new Account(publicKey, "456");
+    });
+
+    const result = await sendPayment(
+      {
+        network: "testnet",
+        horizonUrl: "https://horizon-testnet.stellar.org",
+        publicKey: signer.publicKey(),
+      },
+      {
+        destination,
+        amount: "10.5000000",
+      },
+      {
+        createServer: () => ({
+          loadAccount,
+          submitTransaction,
+        }),
+      }
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        hash: "payment-hash",
+        operation: "payment",
+        destination,
+        amount: "10.5000000",
+        asset: { type: "native" },
+      })
+    );
+    expect(loadAccount).toHaveBeenCalledWith(signer.publicKey());
+    expect(loadAccount).toHaveBeenCalledWith(destination);
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a new account when sending native XLM to an unfunded address", async () => {
+    const signer = Keypair.random();
+    const destination = Keypair.random().publicKey();
+    process.env.STELLAR_PRIVATE_KEY = signer.secret();
+
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: "create-account-hash" });
+    const loadAccount = vi.fn(async (publicKey: string) => {
+      if (publicKey === signer.publicKey()) {
+        return new Account(publicKey, "123");
+      }
+
+      throw { response: { status: 404 } };
+    });
+
+    const result = await sendPayment(
+      {
+        network: "testnet",
+        horizonUrl: "https://horizon-testnet.stellar.org",
+        publicKey: signer.publicKey(),
+      },
+      {
+        destination,
+        amount: "2.0000000",
+      },
+      {
+        createServer: () => ({
+          loadAccount,
+          submitTransaction,
+        }),
+      }
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        hash: "create-account-hash",
+        operation: "create-account",
+        destination,
+      })
+    );
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks issued-asset payments when the destination lacks the trustline", async () => {
+    const signer = Keypair.random();
+    const destination = Keypair.random().publicKey();
+    const issuer = Keypair.random().publicKey();
+    process.env.STELLAR_PRIVATE_KEY = signer.secret();
+
+    const loadAccount = vi.fn(async (publicKey: string) => {
+      if (publicKey === signer.publicKey()) {
+        return new Account(publicKey, "123");
+      }
+
+      return {
+        ...new Account(publicKey, "456"),
+        balances: [{ asset_type: "native" }],
+      };
+    });
+
+    await expect(
+      sendPayment(
+        {
+          network: "testnet",
+          horizonUrl: "https://horizon-testnet.stellar.org",
+          publicKey: signer.publicKey(),
+        },
+        {
+          destination,
+          amount: "5",
+          asset: {
+            code: "USDC",
+            issuer,
+          },
+        },
+        {
+          createServer: () => ({
+            loadAccount,
+            submitTransaction: vi.fn(),
+          }),
+        }
+      )
+    ).rejects.toThrow("Destination account does not trust the requested asset");
+  });
+
+  it("allows issued-asset payments when the destination already trusts the asset", async () => {
+    const signer = Keypair.random();
+    const destination = Keypair.random().publicKey();
+    const issuer = Keypair.random().publicKey();
+    process.env.STELLAR_PRIVATE_KEY = signer.secret();
+
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: "asset-payment-hash" });
+    const loadAccount = vi.fn(async (publicKey: string) => {
+      if (publicKey === signer.publicKey()) {
+        return new Account(publicKey, "123");
+      }
+
+      return {
+        ...new Account(publicKey, "456"),
+        balances: [
+          { asset_type: "native" },
+          {
+            asset_type: "credit_alphanum4",
+            asset_code: "USDC",
+            asset_issuer: issuer,
+          },
+        ],
+      };
+    });
+
+    const result = await sendPayment(
+      {
+        network: "testnet",
+        horizonUrl: "https://horizon-testnet.stellar.org",
+        publicKey: signer.publicKey(),
+      },
+      {
+        destination,
+        amount: "5.2500000",
+        asset: {
+          code: "USDC",
+          issuer,
+        },
+        memo: "invoice-42",
+      },
+      {
+        createServer: () => ({
+          loadAccount,
+          submitTransaction,
+        }),
+      }
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        hash: "asset-payment-hash",
+        operation: "payment",
+        memo: "invoice-42",
+        asset: {
+          code: "USDC",
+          issuer,
+        },
+      })
+    );
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates amount precision and memo size before building a transaction", async () => {
+    const signer = Keypair.random();
+    const destination = Keypair.random().publicKey();
+    process.env.STELLAR_PRIVATE_KEY = signer.secret();
+
+    await expect(
+      sendPayment(
+        {
+          network: "testnet",
+          horizonUrl: "https://horizon-testnet.stellar.org",
+          publicKey: signer.publicKey(),
+        },
+        {
+          destination,
+          amount: "1.12345678",
+        },
+        {
+          createServer: () => ({
+            loadAccount: vi.fn(),
+            submitTransaction: vi.fn(),
+          }),
+        }
+      )
+    ).rejects.toThrow("Amount cannot have more than 7 decimal places");
+
+    await expect(
+      sendPayment(
+        {
+          network: "testnet",
+          horizonUrl: "https://horizon-testnet.stellar.org",
+          publicKey: signer.publicKey(),
+        },
+        {
+          destination,
+          amount: "1",
+          memo: "12345678901234567890123456789",
+        },
+        {
+          createServer: () => ({
+            loadAccount: vi.fn(),
+            submitTransaction: vi.fn(),
+          }),
+        }
+      )
+    ).rejects.toThrow("Memo must be 28 bytes or fewer");
+  });
+});

--- a/tests/unit/tools/stellar.test.ts
+++ b/tests/unit/tools/stellar.test.ts
@@ -1,22 +1,123 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-describe('Stellar Tool', () => {
-  describe('Network Support', () => {
-    it('should support testnet network', () => {
-      const network = 'testnet';
-      expect(network).toBe('testnet');
+describe("stellarSendPaymentTool", () => {
+  const originalPublicKey = process.env.STELLAR_PUBLIC_KEY;
+
+  beforeEach(() => {
+    process.env.STELLAR_PUBLIC_KEY =
+      "GDQP2KPQGKIHYJGXNUIYOMHARUARCA6LK6GITSTKOXFWUCIM5T5RZVBR";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+
+    if (originalPublicKey === undefined) {
+      delete process.env.STELLAR_PUBLIC_KEY;
+      return;
+    }
+
+    process.env.STELLAR_PUBLIC_KEY = originalPublicKey;
+  });
+
+  it("blocks mainnet execution unless allowMainnet is enabled", async () => {
+    vi.doMock("../../../lib/payments", () => ({
+      sendPayment: vi.fn(),
+    }));
+
+    const { stellarSendPaymentTool } = await import("../../../tools/stellar");
+
+    await expect(
+      stellarSendPaymentTool.func({
+        recipient: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+        amount: "10",
+        network: "mainnet",
+      })
+    ).rejects.toThrow("allowMainnet: true is required for mainnet payments");
+  });
+
+  it("forwards asset, memo, and Horizon overrides to the payment library", async () => {
+    const publicKey = process.env.STELLAR_PUBLIC_KEY!;
+    const sendPayment = vi.fn().mockResolvedValue({
+      hash: "payment-hash",
+      network: "testnet",
+      operation: "payment",
+      destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+      amount: "12.5000000",
+      asset: { code: "USDC", issuer: publicKey },
+      memo: "invoice-7",
     });
 
-    it('should support mainnet network', () => {
-      const network = 'mainnet';
-      expect(network).toBe('mainnet');
+    vi.doMock("../../../lib/payments", () => ({
+      sendPayment,
+    }));
+
+    const { stellarSendPaymentTool } = await import("../../../tools/stellar");
+
+    const result = await stellarSendPaymentTool.func({
+      recipient: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+      amount: "12.5000000",
+      asset: { code: "USDC", issuer: publicKey },
+      memo: "invoice-7",
+      horizonUrl: "https://custom-horizon.example",
     });
 
-    it('should validate both network types', () => {
-      const networks = ['testnet', 'mainnet'];
-      expect(networks).toHaveLength(2);
-      expect(networks).toContain('testnet');
-      expect(networks).toContain('mainnet');
+    expect(JSON.parse(result)).toEqual({
+      hash: "payment-hash",
+      network: "testnet",
+      operation: "payment",
+      destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+      amount: "12.5000000",
+      asset: { code: "USDC", issuer: publicKey },
+      memo: "invoice-7",
     });
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        network: "testnet",
+        publicKey,
+        horizonUrl: "https://custom-horizon.example",
+      }),
+      expect.objectContaining({
+        destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+        amount: "12.5000000",
+        asset: { code: "USDC", issuer: publicKey },
+        memo: "invoice-7",
+      })
+    );
+  });
+
+  it("uses mainnet defaults when explicitly allowed", async () => {
+    const sendPayment = vi.fn().mockResolvedValue({
+      hash: "mainnet-hash",
+      network: "mainnet",
+      operation: "payment",
+      destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+      amount: "1",
+      asset: { type: "native" },
+    });
+
+    vi.doMock("../../../lib/payments", () => ({
+      sendPayment,
+    }));
+
+    const { stellarSendPaymentTool } = await import("../../../tools/stellar");
+
+    await stellarSendPaymentTool.func({
+      recipient: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+      amount: "1",
+      network: "mainnet",
+      allowMainnet: true,
+    });
+
+    expect(sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        network: "mainnet",
+        horizonUrl: "https://horizon.stellar.org",
+      }),
+      expect.objectContaining({
+        destination: "GBRPYHIL2C3Z3QKYLH6N2IYVMZT7B4M4U7CUC3VQ44S2M2XNO4M6JJ74",
+        amount: "1",
+      })
+    );
   });
 });

--- a/tools/stellar.ts
+++ b/tools/stellar.ts
@@ -1,67 +1,94 @@
 import { DynamicStructuredTool } from "@langchain/core/tools";
 import { z } from "zod";
-import * as StellarSdk from "stellar-sdk";
-// ... import StellarSdk, getPublicKey, connect, signTransaction, etc. as needed ...
+import { sendPayment } from "../lib/payments";
+import type { StellarAssetInput } from "../lib/assets";
+
+const nativeAssetSchema = z.object({
+  type: z.literal("native"),
+});
+
+const issuedAssetSchema = z.object({
+  code: z.string().min(1).max(12),
+  issuer: z.string().min(1),
+});
+
+const assetSchema = z.union([nativeAssetSchema, issuedAssetSchema]);
 
 export const stellarSendPaymentTool = new DynamicStructuredTool({
   name: "stellar_send_payment",
-  description: "Send a payment on the Stellar testnet. Requires recipient address and amount.",
+  description:
+    "Send native XLM or issued-asset payments on Stellar Classic. " +
+    "Supports optional memos and can fund brand-new accounts with native XLM.",
   schema: z.object({
-    recipient: z.string().describe("The Stellar address to send to"),
-    amount: z.string().describe("The amount of XLM to send (as a string)"),
+    recipient: z.string().describe("The Stellar public key to send to"),
+    amount: z.string().describe("The amount to send as a Stellar amount string"),
+    asset: assetSchema
+      .optional()
+      .describe("Optional asset descriptor. Omit to send native XLM."),
+    memo: z
+      .string()
+      .max(28)
+      .optional()
+      .describe("Optional text memo up to 28 bytes"),
+    network: z
+      .enum(["testnet", "mainnet"])
+      .optional()
+      .describe("Target Stellar network. Defaults to testnet."),
+    horizonUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe("Optional Horizon URL override"),
+    allowMainnet: z
+      .boolean()
+      .optional()
+      .describe("Required when network is mainnet"),
   }),
-  func: async ({ recipient, amount }: { recipient: string; amount: string }) => {
-    try {
-      // Step 1: Validate inputs
-      if (!StellarSdk.StrKey.isValidEd25519PublicKey(recipient)) {
-        throw new Error("Invalid recipient address.");
-      }
-      if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
-        throw new Error("Amount must be a positive number.");
-      }
-
-      // Step 2: Get private key from environment
-      const privateKey = process.env.STELLAR_PRIVATE_KEY as string;
-      if (!privateKey || !StellarSdk.StrKey.isValidEd25519SecretSeed(privateKey)) {
-        throw new Error("Invalid or missing Stellar private key in environment.");
-      }
-      const keypair = StellarSdk.Keypair.fromSecret(privateKey);
-      const sourcePublicKey = keypair.publicKey();
-
-      // Step 3: Create an unsigned transaction
-      const server = new StellarSdk.Horizon.Server("https://horizon-testnet.stellar.org");
-      const account = await server.loadAccount(sourcePublicKey);
-
-      const transaction = new StellarSdk.TransactionBuilder(account, {
-        fee: StellarSdk.BASE_FEE,
-        networkPassphrase: StellarSdk.Networks.TESTNET,
-      })
-        .addOperation(
-          StellarSdk.Operation.payment({
-            destination: recipient,
-            asset: StellarSdk.Asset.native(),
-            amount: amount,
-          })
-        )
-        .setTimeout(300)
-        .build();
-
-      // Step 4: Sign the transaction with the private key
-      transaction.sign(keypair);
-      const signedTxXdr = transaction.toXDR();
-
-      // Step 5: Submit the transaction
-      const tx = new StellarSdk.Transaction(signedTxXdr, StellarSdk.Networks.TESTNET);
-      const response = await server.submitTransaction(tx);
-
-      return `Transaction successful! Hash: ${response.hash}`;
-    } catch (error) {
-      const errorMessage =
-        (error as { response?: { data?: { title?: string } }; message?: string })
-          .response?.data?.title ||
-        (error as Error).message ||
-        "Unknown error occurred";
-      return `Transaction failed: ${errorMessage}`;
+  func: async ({
+    recipient,
+    amount,
+    asset,
+    memo,
+    network,
+    horizonUrl,
+    allowMainnet,
+  }: {
+    recipient: string;
+    amount: string;
+    asset?: StellarAssetInput;
+    memo?: string;
+    network?: "testnet" | "mainnet";
+    horizonUrl?: string;
+    allowMainnet?: boolean;
+  }) => {
+    const selectedNetwork = network ?? "testnet";
+    if (selectedNetwork === "mainnet" && !allowMainnet) {
+      throw new Error("allowMainnet: true is required for mainnet payments");
     }
+
+    const publicKey = process.env.STELLAR_PUBLIC_KEY;
+    if (!publicKey) {
+      throw new Error("Missing STELLAR_PUBLIC_KEY");
+    }
+
+    const result = await sendPayment(
+      {
+        network: selectedNetwork,
+        horizonUrl:
+          horizonUrl ??
+          (selectedNetwork === "mainnet"
+            ? "https://horizon.stellar.org"
+            : "https://horizon-testnet.stellar.org"),
+        publicKey,
+      },
+      {
+        destination: recipient,
+        amount,
+        asset,
+        memo,
+      }
+    );
+
+    return JSON.stringify(result, null, 2);
   },
 });


### PR DESCRIPTION
## Summary
- add reusable Stellar payment support for native XLM and issued assets
- validate destination trustlines for issued-asset payments
- fall back to `createAccount` when funding an unfunded address with native XLM
- add memo support and mainnet safety gating in the payment tool
- expose the payment flow through `AgentClient` and document it in the README

## Validation
- `npm run build`
- `npm test` (64/64 passing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reusable Stellar payment flow for native XLM and issued assets with trustline checks, safe account funding, and stricter asset validation. Exposes payments via `AgentClient.sendPayment` and the `stellar_send_payment` tool, with memo support and mainnet safety gating.

- **New Features**
  - `lib/payments.sendPayment()` sends XLM or issued assets; checks destination trustlines; auto-creates accounts for native to unfunded addresses; validates amount precision and 28-byte text memos; returns tx hash and metadata.
  - `AgentClient.sendPayment(...)` wrapper and README examples.
  - `stellar_send_payment` tool forwards asset, memo, and Horizon overrides; blocks mainnet unless `allowMainnet` is true.

- **Bug Fixes**
  - Tightened native asset detection in `lib/assets.ts` to only accept `{ type: "native" }`, preventing malformed issued assets from being treated as native; added tests.

<sup>Written for commit fe241a1d26307cab84ddf8b3e51177a68235ad0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

