### PR TITLE
fix: improve error messages for swap operations (closes #3)

### DIFF
--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -208,6 +208,8 @@ import {
     inMax: string,
     config?: SorobanContractConfig
   ) {
+    const network = config?.network ?? "testnet";
+    const asset = buyA ? "asset A" : "asset B";
     try {
       const toScVal = addressToScVal(to);
       const buyAScVal = booleanToScVal(buyA);
@@ -217,9 +219,12 @@ import {
       if (config?.simulate) return result as any; // Forward the simulation text
       console.log(`Swapped successfully to ${to}`);
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error("Failed to swap:", errorMessage);
-      throw error;
+      const cause = error instanceof Error ? error.message : String(error);
+      const message =
+        `Swap failed on ${network}: could not swap ${out} of ${asset} ` +
+        `(max input: ${inMax}) to ${to}. Cause: ${cause}`;
+      console.error(message);
+      throw new Error(message);
     }
   }
   

--- a/lib/dex.ts
+++ b/lib/dex.ts
@@ -195,7 +195,16 @@ export async function quoteSwap(
   const response = await fetchImpl(buildPathEndpointUrl(client, params));
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch path quotes: ${response.status} ${response.statusText}`);
+    const sendDesc = assetInputToHorizonAsset(params.sendAsset);
+    const destDesc = assetInputToHorizonAsset(params.destAsset);
+    const amountDesc =
+      params.mode === "strict-send"
+        ? `send ${params.sendAmount} ${sendDesc}`
+        : `receive ${params.destAmount} ${destDesc}`;
+    throw new Error(
+      `Failed to fetch ${params.mode} path quotes on ${client.network} ` +
+      `(${amountDesc} → ${destDesc}): ${response.status} ${response.statusText}`
+    );
   }
 
   const payload = (await response.json()) as HorizonPathResponse;
@@ -223,7 +232,16 @@ export async function swapBestRoute(
   const bestQuote = quotes[0];
 
   if (!bestQuote) {
-    throw new Error("No route available for the requested swap");
+    const sendDesc = assetInputToHorizonAsset(params.sendAsset);
+    const destDesc = assetInputToHorizonAsset(params.destAsset);
+    const amountDesc =
+      params.mode === "strict-send"
+        ? `${params.sendAmount} ${sendDesc}`
+        : `${params.destAmount} ${destDesc}`;
+    throw new Error(
+      `No route available on ${client.network} for ${params.mode} swap: ` +
+      `${amountDesc} → ${destDesc}`
+    );
   }
 
   const createServer =
@@ -417,7 +435,8 @@ async function validateDestinationAssetSupport(
 
   if (!supportsAsset) {
     throw new Error(
-      "Destination account does not trust the requested destination asset"
+      `Destination account ${destination} does not have a trustline for ` +
+      `${destAsset.code}:${destAsset.issuer} on ${client.network}`
     );
   }
 }

--- a/tests/unit/lib/dex.test.ts
+++ b/tests/unit/lib/dex.test.ts
@@ -368,7 +368,7 @@ describe("dex helpers", () => {
         },
         { fetchImpl }
       )
-    ).rejects.toThrow("Destination account does not trust the requested destination asset");
+    ).rejects.toThrow("does not have a trustline for");
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Closes #3

Swap-related failures previously threw generic or context-free errors, making debugging difficult. This PR replaces them with descriptive messages that include the relevant parameters.

## Changes

### `lib/contract.ts` — `swap()`
Before:
```
Failed to swap: <cause>
```
After:
```
Swap failed on testnet: could not swap 100 of asset A (max input: 110) to G…XYZ. Cause: <cause>
```

### `lib/dex.ts` — `quoteSwap()`
Before:
```
Failed to fetch path quotes: 400 Bad Request
```
After:
```
Failed to fetch strict-send path quotes on testnet (send 25 USDC:G… → EURC:G…): 400 Bad Request
```

### `lib/dex.ts` — `swapBestRoute()`
Before:
```
No route available for the requested swap
```
After:
```
No route available on testnet for strict-send swap: 25 USDC:G… → EURC:G…
```

### `lib/dex.ts` — `validateDestinationAssetSupport()`
Before:
```
Destination account does not trust the requested destination asset
```
After:
```
Destination account G…ABC does not have a trustline for EURC:G… on testnet
```

## Testing
- Updated `tests/unit/lib/dex.test.ts` to match the new trustline error message
- All 59 existing tests pass (`npm test`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved swap error messages across the flow with clear context (network, mode, amounts, assets, destination) to make failures easier to debug and act on.

- **Bug Fixes**
  - `lib/contract.ts` `swap()`: include network, asset side, out amount, `inMax`, and destination in errors.
  - `lib/dex.ts` `quoteSwap()`: include mode, network, send/dest assets, and amount in HTTP failure errors.
  - `lib/dex.ts` `swapBestRoute()`: include mode, network, and asset pair in “no route” errors.
  - `lib/dex.ts` `validateDestinationAssetSupport()`: include destination account and `code:issuer` on the network.
  - Tests updated to match the new trustline error; all tests pass.

<sup>Written for commit 02e1f757924d46dc4ebf292be4553ffa4b5be0b0. Summary will update on new commits. <a href="https://cubic.dev/pr/Stellar-Tools/Stellar-AgentKit/pull/68?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

