### PR TITLE
fix: improve error messages for swap operations

### DIFF
--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -131,7 +131,10 @@ import {
   
       if (txResponse.status !== "SUCCESS") {
         console.error(`Transaction failed for ${functName} with status: ${txResponse.status}`, JSON.stringify(txResponse, null, 2));
-        throw new Error(`Transaction failed with status: ${txResponse.status}`);
+        throw new Error(
+          `Transaction failed with status: ${txResponse.status} ` +
+          `(function: ${functName}, contract: ${targetContractId}, network: ${config.network})`
+        );
       }
   
       // Parse return value if present (e.g., for withdraw)
@@ -219,7 +222,10 @@ import {
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("Failed to swap:", errorMessage);
-      throw error;
+      throw new Error(
+        `Failed to swap (to=${to}, buyA=${buyA}, out=${out}, inMax=${inMax}, ` +
+        `network=${config?.network ?? "testnet"}): ${errorMessage}`
+      );
     }
   }
   

--- a/lib/dex.ts
+++ b/lib/dex.ts
@@ -195,7 +195,16 @@ export async function quoteSwap(
   const response = await fetchImpl(buildPathEndpointUrl(client, params));
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch path quotes: ${response.status} ${response.statusText}`);
+    const sendAssetLabel = assetInputToHorizonAsset(params.sendAsset);
+    const destAssetLabel = assetInputToHorizonAsset(params.destAsset);
+    const amountLabel = params.mode === "strict-send"
+      ? `sendAmount=${params.sendAmount}`
+      : `destAmount=${params.destAmount}`;
+    throw new Error(
+      `Failed to fetch path quotes for ${params.mode} swap ` +
+      `(${sendAssetLabel} → ${destAssetLabel}, ${amountLabel}) ` +
+      `on ${client.network}: ${response.status} ${response.statusText}`
+    );
   }
 
   const payload = (await response.json()) as HorizonPathResponse;
@@ -223,7 +232,16 @@ export async function swapBestRoute(
   const bestQuote = quotes[0];
 
   if (!bestQuote) {
-    throw new Error("No route available for the requested swap");
+    const sendAssetLabel = assetInputToHorizonAsset(params.sendAsset);
+    const destAssetLabel = assetInputToHorizonAsset(params.destAsset);
+    const amountLabel = params.mode === "strict-send"
+      ? `sendAmount=${params.sendAmount}`
+      : `destAmount=${params.destAmount}`;
+    throw new Error(
+      `No route available for ${params.mode} swap ` +
+      `(${sendAssetLabel} → ${destAssetLabel}, ${amountLabel}) ` +
+      `on ${client.network}`
+    );
   }
 
   const createServer =
@@ -417,7 +435,8 @@ async function validateDestinationAssetSupport(
 
   if (!supportsAsset) {
     throw new Error(
-      "Destination account does not trust the requested destination asset"
+      `Destination account ${destination} does not trust asset ${destAsset.code}:${destAsset.issuer}. ` +
+      `The destination account must have a trustline for this asset before receiving it.`
     );
   }
 }

--- a/tests/integration/dex-workflow.test.ts
+++ b/tests/integration/dex-workflow.test.ts
@@ -158,7 +158,7 @@ describe("dex workflow", () => {
         },
         { fetchImpl }
       )
-    ).rejects.toThrow("No route available");
+    ).rejects.toThrow("No route available for");
   });
 
   it("surfaces destination trustline-style submission failures", async () => {

--- a/tests/unit/lib/dex.test.ts
+++ b/tests/unit/lib/dex.test.ts
@@ -368,7 +368,7 @@ describe("dex helpers", () => {
         },
         { fetchImpl }
       )
-    ).rejects.toThrow("Destination account does not trust the requested destination asset");
+    ).rejects.toThrow("does not trust asset EUR:");
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Closes #3

Improves error messages across swap-related code paths so developers get actionable context when operations fail.

## Changes

**`lib/dex.ts`**
- `quoteSwap`: `Failed to fetch path quotes` now includes asset pair, amount, mode, and network
- `swapBestRoute`: `No route available` now includes asset pair, amount, mode, and network
- `validateDestinationAssetSupport`: trustline error now includes the destination account address and the specific `code:issuer` of the asset

**`lib/contract.ts`**
- `contractInt`: `Transaction failed with status` now includes the function name, contract address, and network
- `swap`: `Failed to swap` now includes `to`, `buyA`, `out`, `inMax`, and network

**Tests**
- Updated two test assertions to match the new message substrings

## Verification

- `tsc --noEmit`: ✅ no errors
- `vitest run`: ✅ 59/59 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves swap error messages with asset pair, amount/mode, network, and addresses for better debugging. Closes #3.

- **Bug Fixes**
  - `lib/dex`: Enriched `quoteSwap` and `swapBestRoute` errors with send/dest assets, amount, mode, and network; trustline error now includes destination account and `code:issuer`.
  - `lib/contract`: Transaction error now includes function, contract, and network; `swap` error now includes `to`, `buyA`, `out`, `inMax`, and network.
  - Tests: Updated two assertions to match the new message fragments.

<sup>Written for commit 80c29edd847d0dc002b6a0c34652593cc012bfd7. Summary will update on new commits. <a href="https://cubic.dev/pr/Stellar-Tools/Stellar-AgentKit/pull/74?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

