### PR TITLE
feat: add Claimable Balance support across lib, AgentClient, and Lang…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ multiple operations into a single programmable and extensible toolkit.
 - Liquidity pool (LP) deposits & withdrawals
 - Querying pool reserves and share IDs
 - Custom contract integrations (current)
+- Claimable balances for conditional / time-locked payments (escrow & vesting)
 - Designed for future LP provider integrations
 - Supports Testnet & Mainnet
 
@@ -328,6 +329,115 @@ const reserves = await agent.lp.getReserves();
 // Get share token ID
 const shareId = await agent.lp.getShareId();
 ```
+
+---
+
+## 🔒 Claimable Balances (Conditional / Time-Locked Payments)
+
+Stellar's native primitive for **escrow, vesting, and scheduled payouts** —
+ideal for AI-agent workflows where funds must be released only when a
+predicate is satisfied. Exposed in three ways:
+
+1. Programmatic API on `AgentClient` → `agent.claimable.*`
+2. LangChain `DynamicStructuredTool` → `StellarClaimableBalanceTool` (auto-included in `stellarTools`)
+3. Lower-level functions in `lib/claimableBalance` (`createClaimableBalance`, `claimClaimableBalance`, `listClaimableBalances`, `buildPredicate`)
+
+### Programmatic API
+
+```typescript
+import { AgentClient } from "stellartools";
+
+const agent = new AgentClient({ network: "testnet" });
+
+// 1. Lock 100 XLM for `recipient`, claimable any time within the next 24h
+const created = await agent.claimable.create({
+  sourceSecret: process.env.SOURCE_SECRET!,
+  asset: { code: "XLM" },
+  amount: "100",
+  claimants: [
+    {
+      destination: "GRECIPIENT...",
+      predicate: { type: "beforeRelativeTime", seconds: 86400 },
+    },
+  ],
+});
+console.log(created.transactionHash, created.balanceIds);
+
+// 2. List claimable balances awaiting a specific account
+const open = await agent.claimable.list({ claimant: "GRECIPIENT..." });
+
+// 3. Claim a balance
+await agent.claimable.claim({
+  claimerSecret: process.env.RECIPIENT_SECRET!,
+  balanceId: created.balanceIds[0],
+});
+```
+
+### Composable Predicates
+
+| Type                | Meaning                                            |
+| ------------------- | -------------------------------------------------- |
+| `unconditional`     | Always claimable                                   |
+| `beforeRelativeTime`| Claimable for N seconds after creation             |
+| `beforeAbsoluteTime`| Claimable until a Unix epoch timestamp             |
+| `not`               | Negation of an inner predicate                     |
+| `and` / `or`        | Logical combination of two inner predicates        |
+
+```typescript
+// Two-party escrow: claimable AFTER `releaseAt` AND BEFORE 24h elapse
+const predicate = {
+  type: "and",
+  predicates: [
+    { type: "beforeRelativeTime", seconds: 86400 },
+    {
+      type: "not",
+      predicate: { type: "beforeAbsoluteTime", epochSeconds: releaseAt },
+    },
+  ],
+};
+```
+
+### Defaults & Overrides
+
+The lib exposes the relevant Stellar protocol limits as named exports
+(no magic numbers in user code):
+
+```typescript
+import {
+  MAX_CLAIMANTS_PER_BALANCE,        // 10  (per-balance protocol cap)
+  MAX_OPERATIONS_PER_TRANSACTION,   // 100 (default per-tx ops cap)
+  MAX_PREDICATE_DEPTH,              // 5   (default predicate nesting)
+  DEFAULT_TRANSACTION_TIMEOUT_SECONDS,
+} from "stellartools";
+
+// All of these are overridable per-call via `options`:
+await agent.claimable.create({
+  sourceSecret,
+  asset: { code: "XLM" },
+  amount: "1",
+  claimants,
+  options: {
+    maxOperationsPerTransaction: 50,
+    maxPredicateDepth: 3,
+    transactionTimeoutSeconds: 60,
+    baseFee: "200",
+  },
+});
+```
+
+### LangChain Tool
+
+`StellarClaimableBalanceTool` is auto-bundled into `stellarTools`, so AI
+agents can call `create`, `claim`, and `list` directly via natural language:
+
+> _"Lock 50 XLM for GABCD... claimable any time within the next 2 hours."_
+
+It reads `STELLAR_PRIVATE_KEY` for `create`, and either
+`STELLAR_CLAIMER_PRIVATE_KEY` (preferred) or `STELLAR_PRIVATE_KEY` for
+`claim`. The tool always returns JSON (`{ ok, ... }`) so agents can parse
+the result deterministically.
+
+A runnable example lives at `examples/claimable-balance-example.ts`.
 
 ---
 

--- a/agent.ts
+++ b/agent.ts
@@ -15,6 +15,20 @@ import {
   type SwapBestRouteResult,
 } from "./lib/dex";
 import { bridgeTokenTool } from "./tools/bridge";
+import {
+  createClaimableBalance as cbCreate,
+  claimClaimableBalance as cbClaim,
+  listClaimableBalances as cbList,
+  type CreateClaimableBalanceParams,
+  type CreateClaimableBalanceResult,
+  type ClaimClaimableBalanceParams,
+  type ClaimClaimableBalanceResult,
+  type ListClaimableBalancesParams,
+  type ClaimableBalanceRecord,
+  type ClaimableBalanceOptions,
+  type ClaimPredicate,
+  type ClaimantInput,
+} from "./lib/claimableBalance";
 import { stellarGetBalanceTool, stellarGetAccountInfoTool } from "./tools/stellar";
 import {
   Horizon,
@@ -67,6 +81,15 @@ export type {
   RouteQuote,
   SwapBestRouteParams,
   SwapBestRouteResult,
+  CreateClaimableBalanceParams,
+  CreateClaimableBalanceResult,
+  ClaimClaimableBalanceParams,
+  ClaimClaimableBalanceResult,
+  ListClaimableBalancesParams,
+  ClaimableBalanceRecord,
+  ClaimableBalanceOptions,
+  ClaimPredicate,
+  ClaimantInput,
 };
 
 export class AgentClient {
@@ -280,6 +303,55 @@ export class AgentClient {
           publicKey: this.publicKey,
         },
         params
+      );
+    },
+  };
+
+  /**
+   * Claimable Balances — conditional / time-locked payments (escrow, vesting,
+   * scheduled payouts). Useful for AI-agent workflows where funds must be
+   * released only when a predicate evaluates to true.
+   *
+   * Each input claimant becomes its own `CreateClaimableBalance` operation,
+   * so the returned `balanceIds` map 1:1 with the input `claimants` array.
+   *
+   * @example
+   * // Lock 100 XLM for `recipient`, claimable any time within the next 24h
+   * await agent.claimable.create({
+   *   sourceSecret: process.env.SOURCE_SECRET!,
+   *   asset: { code: "XLM" },
+   *   amount: "100",
+   *   claimants: [{
+   *     destination: recipient,
+   *     predicate: { type: "beforeRelativeTime", seconds: 86400 },
+   *   }],
+   * });
+   */
+  public claimable = {
+    create: async (
+      params: CreateClaimableBalanceParams
+    ): Promise<CreateClaimableBalanceResult> => {
+      return await cbCreate(
+        { network: this.network, horizonUrl: this.rpcUrl },
+        params
+      );
+    },
+
+    claim: async (
+      params: ClaimClaimableBalanceParams
+    ): Promise<ClaimClaimableBalanceResult> => {
+      return await cbClaim(
+        { network: this.network, horizonUrl: this.rpcUrl },
+        params
+      );
+    },
+
+    list: async (
+      params?: ListClaimableBalancesParams
+    ): Promise<ClaimableBalanceRecord[]> => {
+      return await cbList(
+        { network: this.network, horizonUrl: this.rpcUrl },
+        params ?? {}
       );
     },
   };

--- a/examples/claimable-balance-example.ts
+++ b/examples/claimable-balance-example.ts
@@ -13,29 +13,73 @@
  *
  * ⚠️ TESTNET ONLY. Never use mainnet secrets in examples.
  *
+ * Account funding
+ * ---------------
+ * The example needs two funded testnet accounts. It supports two modes:
+ *
+ *   A. Set env vars (preferred for repeated runs):
+ *        EXAMPLE_SOURCE_SECRET=S...
+ *        EXAMPLE_RECIPIENT_SECRET=S...
+ *      The accounts must already be funded on testnet.
+ *
+ *   B. Leave the env vars unset and the script will:
+ *        - generate two fresh keypairs,
+ *        - auto-fund them via the Friendbot faucet, and
+ *        - print the secrets so you can re-use them on subsequent runs.
+ *
  * Run with: ts-node examples/claimable-balance-example.ts
  */
 
 import { AgentClient } from "../agent";
-import { Keypair } from "@stellar/stellar-sdk";
+import { Horizon, Keypair } from "@stellar/stellar-sdk";
+
+const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const FRIENDBOT_URL = "https://friendbot.stellar.org";
+
+/**
+ * Resolve a keypair from an env var (preferred) or generate + fund a fresh one
+ * via Friendbot. Verifies on-chain funding before returning so the rest of the
+ * example can rely on the account existing.
+ */
+async function resolveAccount(
+  label: string,
+  envVar: string,
+  server: Horizon.Server
+): Promise<Keypair> {
+  const fromEnv = process.env[envVar];
+  if (fromEnv) {
+    const kp = Keypair.fromSecret(fromEnv);
+    await server.loadAccount(kp.publicKey()); // throws if not funded
+    console.log(`  ✓ ${label}: ${kp.publicKey()} (from ${envVar})`);
+    return kp;
+  }
+
+  const kp = Keypair.random();
+  console.log(`  … ${label}: ${kp.publicKey()} (funding via Friendbot…)`);
+
+  const res = await fetch(`${FRIENDBOT_URL}?addr=${encodeURIComponent(kp.publicKey())}`);
+  if (!res.ok) {
+    throw new Error(
+      `Friendbot funding failed for ${label} (${res.status} ${res.statusText}). ` +
+        `Set ${envVar} to a pre-funded testnet secret to skip Friendbot.`
+    );
+  }
+  await server.loadAccount(kp.publicKey());
+  console.log(`  ✓ ${label} funded. Save the secret to re-use on next run:`);
+  console.log(`      export ${envVar}=${kp.secret()}`);
+  return kp;
+}
 
 async function exampleClaimableBalances() {
   console.log("🔒 Claimable Balance Example");
   console.log("=".repeat(60));
 
   const agent = new AgentClient({ network: "testnet" });
+  const server = new Horizon.Server(HORIZON_URL);
 
-  // In real usage, source/recipient would be funded testnet accounts.
-  const source = Keypair.random();
-  const recipient = Keypair.random();
-
-  console.log("\nGenerated test accounts:");
-  console.log(`  Source:    ${source.publicKey()}`);
-  console.log(`  Recipient: ${recipient.publicKey()}`);
-  console.log(
-    "\n⚠️  Fund these accounts on testnet before running for real:\n" +
-      "    https://laboratory.stellar.org/#account-creator?network=test"
-  );
+  console.log("\nResolving testnet accounts:");
+  const source = await resolveAccount("source   ", "EXAMPLE_SOURCE_SECRET", server);
+  const recipient = await resolveAccount("recipient", "EXAMPLE_RECIPIENT_SECRET", server);
 
   // ─── 1. Create ─────────────────────────────────────────────────────────
   // Lock 50 XLM for the recipient. Two layered conditions, expressed as a
@@ -89,10 +133,15 @@ async function exampleClaimableBalances() {
   );
 
   // ─── 3. Claim ──────────────────────────────────────────────────────────
-  // In a real flow you'd wait until the predicate is satisfied. Here we
-  // demonstrate the call shape — Horizon will reject the claim with a
-  // descriptive error if the predicate is not yet satisfied.
-  console.log("\nAttempting to claim (will fail if predicate not yet satisfied)...");
+  // Wait until the predicate window opens, then claim. Horizon rejects claims
+  // whose predicate is not yet satisfied with a descriptive error — we surface
+  // that for visibility before retrying.
+  const waitMs = Math.max(0, releaseAtUnix * 1000 - Date.now()) + 2_000;
+  console.log(
+    `\nWaiting ${Math.ceil(waitMs / 1000)}s for the predicate to open before claiming…`
+  );
+  await new Promise((r) => setTimeout(r, waitMs));
+
   try {
     const claimed = await agent.claimable.claim({
       claimerSecret: recipient.secret(),
@@ -101,8 +150,9 @@ async function exampleClaimableBalances() {
     console.log(`✅ Claimed! Tx hash: ${claimed.transactionHash}`);
   } catch (err) {
     console.log(
-      `⏳ Not yet claimable (expected): ${(err as Error).message}\n` +
-        `   Wait until ${new Date(releaseAtUnix * 1000).toISOString()} and retry.`
+      `❌ Claim failed: ${(err as Error).message}\n` +
+        `   If the error is 'predicate not satisfied', the example may have been ` +
+        `interrupted before the window opened — re-run to retry.`
     );
   }
 }

--- a/examples/claimable-balance-example.ts
+++ b/examples/claimable-balance-example.ts
@@ -1,0 +1,113 @@
+/**
+ * Claimable Balance Usage Example
+ *
+ * Demonstrates the three claimable-balance flows exposed by AgentKit:
+ *   1. create  — lock funds with a (possibly composite) claim predicate
+ *   2. list    — discover open claimable balances for a recipient
+ *   3. claim   — release the locked funds to the recipient
+ *
+ * Use cases this enables for AI agents:
+ *   - Conditional payouts (only pay if X happens before deadline)
+ *   - Vesting / scheduled payments
+ *   - Two-party escrow (either party can claim before / after deadline)
+ *
+ * ⚠️ TESTNET ONLY. Never use mainnet secrets in examples.
+ *
+ * Run with: ts-node examples/claimable-balance-example.ts
+ */
+
+import { AgentClient } from "../agent";
+import { Keypair } from "@stellar/stellar-sdk";
+
+async function exampleClaimableBalances() {
+  console.log("🔒 Claimable Balance Example");
+  console.log("=".repeat(60));
+
+  const agent = new AgentClient({ network: "testnet" });
+
+  // In real usage, source/recipient would be funded testnet accounts.
+  const source = Keypair.random();
+  const recipient = Keypair.random();
+
+  console.log("\nGenerated test accounts:");
+  console.log(`  Source:    ${source.publicKey()}`);
+  console.log(`  Recipient: ${recipient.publicKey()}`);
+  console.log(
+    "\n⚠️  Fund these accounts on testnet before running for real:\n" +
+      "    https://laboratory.stellar.org/#account-creator?network=test"
+  );
+
+  // ─── 1. Create ─────────────────────────────────────────────────────────
+  // Lock 50 XLM for the recipient. Two layered conditions, expressed as a
+  // composite predicate:
+  //   - claimable for the next 24h (beforeRelativeTime: 86400s)
+  //   - AND only after the configured "release time" has passed
+  //     (i.e. NOT before that absolute timestamp)
+  const releaseAtUnix = Math.floor(Date.now() / 1000) + 60; // 60s from now
+
+  console.log("\nCreating claimable balance with composite predicate:");
+  console.log(`  Amount:     50 XLM`);
+  console.log(`  Window:     next 24h`);
+  console.log(`  Earliest:   ${new Date(releaseAtUnix * 1000).toISOString()}`);
+
+  const created = await agent.claimable.create({
+    sourceSecret: source.secret(),
+    asset: { code: "XLM" },
+    amount: "50",
+    claimants: [
+      {
+        destination: recipient.publicKey(),
+        predicate: {
+          type: "and",
+          predicates: [
+            { type: "beforeRelativeTime", seconds: 86400 },
+            {
+              type: "not",
+              predicate: {
+                type: "beforeAbsoluteTime",
+                epochSeconds: releaseAtUnix,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  console.log("\n✅ Created!");
+  console.log(`  Tx hash:    ${created.transactionHash}`);
+  console.log(`  Balance id: ${created.balanceIds[0]}`);
+
+  // ─── 2. List ───────────────────────────────────────────────────────────
+  console.log("\nListing open claimable balances for recipient...");
+  const open = await agent.claimable.list({
+    claimant: recipient.publicKey(),
+  });
+  console.log(`  Found ${open.length} balance(s).`);
+  open.forEach((b) =>
+    console.log(`    - ${b.id}  amount=${b.amount} asset=${b.asset}`)
+  );
+
+  // ─── 3. Claim ──────────────────────────────────────────────────────────
+  // In a real flow you'd wait until the predicate is satisfied. Here we
+  // demonstrate the call shape — Horizon will reject the claim with a
+  // descriptive error if the predicate is not yet satisfied.
+  console.log("\nAttempting to claim (will fail if predicate not yet satisfied)...");
+  try {
+    const claimed = await agent.claimable.claim({
+      claimerSecret: recipient.secret(),
+      balanceId: created.balanceIds[0],
+    });
+    console.log(`✅ Claimed! Tx hash: ${claimed.transactionHash}`);
+  } catch (err) {
+    console.log(
+      `⏳ Not yet claimable (expected): ${(err as Error).message}\n` +
+        `   Wait until ${new Date(releaseAtUnix * 1000).toISOString()} and retry.`
+    );
+  }
+}
+
+exampleClaimableBalances().catch((err) => {
+  console.error("Example failed:", err);
+  process.exit(1);
+});

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,16 @@ import { StellarLiquidityContractTool } from "./tools/contract";
 import { StellarDexTool } from "./tools/dex";
 import { StellarContractTool } from "./tools/stake";
 import { stellarSendPaymentTool, stellarGetBalanceTool, stellarGetAccountInfoTool } from "./tools/stellar";
+import { StellarClaimableBalanceTool } from "./tools/claimableBalance";
+export { StellarClaimableBalanceTool } from "./tools/claimableBalance";
+export {
+  MAX_CLAIMANTS_PER_BALANCE,
+  MAX_OPERATIONS_PER_TRANSACTION,
+  MAX_PREDICATE_DEPTH,
+  DEFAULT_TRANSACTION_TIMEOUT_SECONDS,
+  buildPredicate,
+  extractBalanceIdsFromTransactionResult,
+} from "./lib/claimableBalance";
 import { 
   AgentClient, 
   AgentConfig,
@@ -15,6 +25,15 @@ import type {
   RouteQuote,
   SwapBestRouteParams,
   SwapBestRouteResult,
+  CreateClaimableBalanceParams,
+  CreateClaimableBalanceResult,
+  ClaimClaimableBalanceParams,
+  ClaimClaimableBalanceResult,
+  ListClaimableBalancesParams,
+  ClaimableBalanceRecord,
+  ClaimableBalanceOptions,
+  ClaimPredicate,
+  ClaimantInput,
 } from "./agent";
 
 export { 
@@ -30,6 +49,15 @@ export type {
   RouteQuote,
   SwapBestRouteParams,
   SwapBestRouteResult,
+  CreateClaimableBalanceParams,
+  CreateClaimableBalanceResult,
+  ClaimClaimableBalanceParams,
+  ClaimClaimableBalanceResult,
+  ListClaimableBalancesParams,
+  ClaimableBalanceRecord,
+  ClaimableBalanceOptions,
+  ClaimPredicate,
+  ClaimantInput,
 };
 export const stellarTools = [
   bridgeTokenTool,
@@ -38,5 +66,6 @@ export const stellarTools = [
   StellarContractTool,
   stellarSendPaymentTool,
   stellarGetBalanceTool,
-  stellarGetAccountInfoTool
+  stellarGetAccountInfoTool,
+  StellarClaimableBalanceTool,
 ];

--- a/lib/claimableBalance.ts
+++ b/lib/claimableBalance.ts
@@ -1,0 +1,426 @@
+import {
+  Asset,
+  BASE_FEE,
+  Claimant,
+  Horizon,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+  xdr,
+} from "@stellar/stellar-sdk";
+
+/**
+ * Claimable Balance support for Stellar AgentKit.
+ *
+ * Claimable Balances are a unique Stellar primitive that enable conditional
+ * and time-locked payments — escrow, vesting, scheduled payouts, conditional
+ * disbursements. They are particularly useful for AI-agent workflows where
+ * funds must be released upon predicates (e.g. "after 24h", "before deadline",
+ * "on demand").
+ *
+ * @see https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/claimable-balances
+ */
+
+// ─── Public configuration constants ──────────────────────────────────────
+//
+// These values reflect the Stellar protocol limits at the time of writing.
+// They are exported (and overridable via call-site `options`) so that
+// downstream code is not hard-coded against magic numbers.
+
+/**
+ * Stellar's per-balance protocol limit on claimants for a single
+ * `CreateClaimableBalance` operation.
+ *
+ * NOTE: `createClaimableBalance` below emits one operation per *input*
+ * claimant (so each resulting balance has exactly one claimant), which means
+ * this constant is informational for the public API — it is not used to cap
+ * the size of the `claimants` argument.
+ */
+export const MAX_CLAIMANTS_PER_BALANCE = 10;
+
+/**
+ * Stellar's protocol cap on operations per transaction.
+ *
+ * `createClaimableBalance` emits one `CreateClaimableBalance` op per input
+ * claimant, so this is the effective default upper bound on the size of the
+ * `claimants` array in a single call. Override via `options.maxOperationsPerTransaction`.
+ */
+export const MAX_OPERATIONS_PER_TRANSACTION = 100;
+
+/** Maximum allowed depth of compound (and / or / not) claim predicates. */
+export const MAX_PREDICATE_DEPTH = 5;
+
+/** Default transaction time-bound for create / claim transactions, in seconds. */
+export const DEFAULT_TRANSACTION_TIMEOUT_SECONDS = 180;
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+export type NetworkName = "testnet" | "mainnet";
+
+export interface ClaimableBalanceContext {
+  network: NetworkName;
+  horizonUrl: string;
+}
+
+/** Behaviour-tweaking options shared by the public API entry points. */
+export interface ClaimableBalanceOptions {
+  /** Override the per-tx operation cap. Defaults to `MAX_OPERATIONS_PER_TRANSACTION`. */
+  maxOperationsPerTransaction?: number;
+  /** Override the predicate nesting depth limit. Defaults to `MAX_PREDICATE_DEPTH`. */
+  maxPredicateDepth?: number;
+  /** Override the transaction timeout (seconds). Defaults to `DEFAULT_TRANSACTION_TIMEOUT_SECONDS`. */
+  transactionTimeoutSeconds?: number;
+  /** Override the per-op base fee (stroops). Defaults to `BASE_FEE`. */
+  baseFee?: string;
+}
+
+/**
+ * High-level predicate definition. Mirrors the on-chain semantics but is
+ * expressed as a friendly tagged union for ergonomic use from agent code.
+ */
+export type ClaimPredicate =
+  | { type: "unconditional" }
+  | { type: "beforeRelativeTime"; seconds: number | string }
+  | { type: "beforeAbsoluteTime"; epochSeconds: number | string }
+  | { type: "not"; predicate: ClaimPredicate }
+  | { type: "and"; predicates: [ClaimPredicate, ClaimPredicate] }
+  | { type: "or"; predicates: [ClaimPredicate, ClaimPredicate] };
+
+export interface ClaimantInput {
+  destination: string;
+  predicate?: ClaimPredicate;
+}
+
+export interface AssetInput {
+  code: string;
+  issuer?: string;
+}
+
+export interface CreateClaimableBalanceParams {
+  sourceSecret: string;
+  asset: AssetInput;
+  amount: string;
+  claimants: ClaimantInput[];
+  options?: ClaimableBalanceOptions;
+}
+
+export interface CreateClaimableBalanceResult {
+  transactionHash: string;
+  /** Claimable balance IDs (hex) created by this transaction. */
+  balanceIds: string[];
+}
+
+export interface ClaimClaimableBalanceParams {
+  claimerSecret: string;
+  balanceId: string;
+  options?: ClaimableBalanceOptions;
+}
+
+export interface ClaimClaimableBalanceResult {
+  transactionHash: string;
+  balanceId: string;
+}
+
+export interface ListClaimableBalancesParams {
+  claimant?: string;
+  sponsor?: string;
+  asset?: AssetInput;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ClaimableBalanceRecord {
+  id: string;
+  asset: string;
+  amount: string;
+  sponsor?: string;
+  lastModifiedLedger: number;
+  claimants: Array<{ destination: string; predicate: unknown }>;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function getNetworkPassphrase(network: NetworkName): string {
+  return network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}
+
+function toAsset(input: AssetInput): Asset {
+  if (!input || !input.code) {
+    throw new Error("Asset code is required");
+  }
+  if (input.code.toUpperCase() === "XLM" || input.code === "native") {
+    return Asset.native();
+  }
+  if (!input.issuer) {
+    throw new Error(`Asset ${input.code} requires an issuer`);
+  }
+  return new Asset(input.code, input.issuer);
+}
+
+function validateAmount(amount: string): void {
+  if (typeof amount !== "string" || amount.trim() === "") {
+    throw new Error("amount must be a non-empty string");
+  }
+  if (!/^\d+(\.\d{1,7})?$/.test(amount)) {
+    throw new Error(
+      "amount must be a positive decimal with up to 7 fractional digits"
+    );
+  }
+  if (Number(amount) <= 0) {
+    throw new Error("amount must be greater than zero");
+  }
+}
+
+/**
+ * Build a Stellar SDK xdr.ClaimPredicate from the friendly tagged union.
+ *
+ * Validates inputs (positive durations, balanced compound predicates, depth)
+ * to prevent accidentally creating unclaimable balances.
+ */
+export function buildPredicate(
+  predicate: ClaimPredicate | undefined,
+  depth = 0,
+  maxDepth: number = MAX_PREDICATE_DEPTH
+): xdr.ClaimPredicate {
+  if (depth > maxDepth) {
+    throw new Error(`Claim predicate nesting too deep (max ${maxDepth} levels)`);
+  }
+  if (!predicate || predicate.type === "unconditional") {
+    return Claimant.predicateUnconditional();
+  }
+
+  switch (predicate.type) {
+    case "beforeRelativeTime": {
+      const seconds = String(predicate.seconds);
+      if (!/^\d+$/.test(seconds) || Number(seconds) <= 0) {
+        throw new Error("beforeRelativeTime.seconds must be a positive integer");
+      }
+      return Claimant.predicateBeforeRelativeTime(seconds);
+    }
+    case "beforeAbsoluteTime": {
+      const epoch = String(predicate.epochSeconds);
+      if (!/^\d+$/.test(epoch) || Number(epoch) <= 0) {
+        throw new Error(
+          "beforeAbsoluteTime.epochSeconds must be a positive integer"
+        );
+      }
+      return Claimant.predicateBeforeAbsoluteTime(epoch);
+    }
+    case "not": {
+      if (!predicate.predicate) {
+        throw new Error("`not` predicate requires an inner predicate");
+      }
+      return Claimant.predicateNot(
+        buildPredicate(predicate.predicate, depth + 1, maxDepth)
+      );
+    }
+    case "and": {
+      if (!predicate.predicates || predicate.predicates.length !== 2) {
+        throw new Error("`and` predicate requires exactly 2 inner predicates");
+      }
+      return Claimant.predicateAnd(
+        buildPredicate(predicate.predicates[0], depth + 1, maxDepth),
+        buildPredicate(predicate.predicates[1], depth + 1, maxDepth)
+      );
+    }
+    case "or": {
+      if (!predicate.predicates || predicate.predicates.length !== 2) {
+        throw new Error("`or` predicate requires exactly 2 inner predicates");
+      }
+      return Claimant.predicateOr(
+        buildPredicate(predicate.predicates[0], depth + 1, maxDepth),
+        buildPredicate(predicate.predicates[1], depth + 1, maxDepth)
+      );
+    }
+    default: {
+      const exhaustive: never = predicate;
+      throw new Error(`Unsupported predicate type: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Extract the claimable balance IDs created by a CreateClaimableBalance op
+ * from the transaction's operation result XDR.
+ */
+export function extractBalanceIdsFromTransactionResult(
+  resultXdr: string
+): string[] {
+  const ids: string[] = [];
+  if (!resultXdr) return ids;
+
+  let parsed: xdr.TransactionResult;
+  try {
+    parsed = xdr.TransactionResult.fromXDR(resultXdr, "base64");
+  } catch (err) {
+    return ids;
+  }
+
+  const inner = parsed.result();
+  const switchName = inner.switch().name;
+  if (switchName !== "txSuccess" && switchName !== "txFeeBumpInnerSuccess") {
+    return ids;
+  }
+
+  const opResults =
+    switchName === "txFeeBumpInnerSuccess"
+      ? inner.innerResultPair().result().result().results()
+      : inner.results();
+
+  for (const op of opResults) {
+    const tr = op.tr();
+    if (!tr || tr.switch().name !== "createClaimableBalance") continue;
+    const cbResult = tr.createClaimableBalanceResult();
+    if (cbResult.switch().name !== "createClaimableBalanceSuccess") continue;
+    const balanceId = cbResult.balanceId();
+    ids.push(balanceId.toXDR("hex"));
+  }
+
+  return ids;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Create one or more claimable balances in a single transaction.
+ *
+ * Each claimant + predicate becomes its own `CreateClaimableBalance` operation
+ * so the resulting balance IDs map 1:1 with the input `claimants` array. The
+ * effective upper bound on the array length is the operations-per-transaction
+ * cap (`MAX_OPERATIONS_PER_TRANSACTION`, overridable via `options`).
+ */
+export async function createClaimableBalance(
+  ctx: ClaimableBalanceContext,
+  params: CreateClaimableBalanceParams
+): Promise<CreateClaimableBalanceResult> {
+  const opts = params.options ?? {};
+  const maxOps = opts.maxOperationsPerTransaction ?? MAX_OPERATIONS_PER_TRANSACTION;
+  const maxDepth = opts.maxPredicateDepth ?? MAX_PREDICATE_DEPTH;
+  const timeout = opts.transactionTimeoutSeconds ?? DEFAULT_TRANSACTION_TIMEOUT_SECONDS;
+  const fee = opts.baseFee ?? BASE_FEE;
+
+  if (!params.sourceSecret) {
+    throw new Error("sourceSecret is required");
+  }
+  if (!params.claimants || params.claimants.length === 0) {
+    throw new Error("At least one claimant is required");
+  }
+  if (params.claimants.length > maxOps) {
+    throw new Error(
+      `A single transaction supports at most ${maxOps} claimable-balance operations ` +
+        `(received ${params.claimants.length}). Split the request across multiple transactions.`
+    );
+  }
+  validateAmount(params.amount);
+
+  const sourceKp = Keypair.fromSecret(params.sourceSecret);
+  const asset = toAsset(params.asset);
+  const networkPassphrase = getNetworkPassphrase(ctx.network);
+  const server = new Horizon.Server(ctx.horizonUrl);
+
+  const account = await server.loadAccount(sourceKp.publicKey());
+
+  const claimants = params.claimants.map(
+    (c) => new Claimant(c.destination, buildPredicate(c.predicate, 0, maxDepth))
+  );
+
+  const builder = new TransactionBuilder(account, {
+    fee,
+    networkPassphrase,
+  });
+
+  // One operation per claimant for deterministic 1:1 balanceId mapping.
+  for (const claimant of claimants) {
+    builder.addOperation(
+      Operation.createClaimableBalance({
+        asset,
+        amount: params.amount,
+        claimants: [claimant],
+      })
+    );
+  }
+
+  const tx = builder.setTimeout(timeout).build();
+  tx.sign(sourceKp);
+
+  const result = await server.submitTransaction(tx);
+  const resultXdr =
+    (result as unknown as { result_xdr?: string }).result_xdr ?? "";
+  const balanceIds = extractBalanceIdsFromTransactionResult(resultXdr);
+
+  return { transactionHash: result.hash, balanceIds };
+}
+
+/**
+ * Claim a previously created claimable balance.
+ *
+ * Will fail on-chain if the predicate is not yet satisfied or the claimer is
+ * not in the balance's claimant list — Horizon returns a descriptive error
+ * which is propagated to the caller.
+ */
+export async function claimClaimableBalance(
+  ctx: ClaimableBalanceContext,
+  params: ClaimClaimableBalanceParams
+): Promise<ClaimClaimableBalanceResult> {
+  const opts = params.options ?? {};
+  const timeout = opts.transactionTimeoutSeconds ?? DEFAULT_TRANSACTION_TIMEOUT_SECONDS;
+  const fee = opts.baseFee ?? BASE_FEE;
+
+  if (!params.claimerSecret) {
+    throw new Error("claimerSecret is required");
+  }
+  if (!params.balanceId || !/^[0-9a-fA-F]+$/.test(params.balanceId)) {
+    throw new Error("balanceId must be a hex string");
+  }
+
+  const claimerKp = Keypair.fromSecret(params.claimerSecret);
+  const networkPassphrase = getNetworkPassphrase(ctx.network);
+  const server = new Horizon.Server(ctx.horizonUrl);
+
+  const account = await server.loadAccount(claimerKp.publicKey());
+
+  const tx = new TransactionBuilder(account, {
+    fee,
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.claimClaimableBalance({ balanceId: params.balanceId })
+    )
+    .setTimeout(timeout)
+    .build();
+
+  tx.sign(claimerKp);
+  const result = await server.submitTransaction(tx);
+  return { transactionHash: result.hash, balanceId: params.balanceId };
+}
+
+/**
+ * List claimable balances by claimant, sponsor, or asset.
+ */
+export async function listClaimableBalances(
+  ctx: ClaimableBalanceContext,
+  params: ListClaimableBalancesParams = {}
+): Promise<ClaimableBalanceRecord[]> {
+  const server = new Horizon.Server(ctx.horizonUrl);
+  let call = server.claimableBalances();
+
+  if (params.claimant) call = call.claimant(params.claimant);
+  if (params.sponsor) call = call.sponsor(params.sponsor);
+  if (params.asset) call = call.asset(toAsset(params.asset));
+  if (params.limit) call = call.limit(params.limit);
+  if (params.cursor) call = call.cursor(params.cursor);
+
+  const page = await call.call();
+  return page.records.map((r: any) => ({
+    id: r.id,
+    asset: r.asset,
+    amount: r.amount,
+    sponsor: r.sponsor,
+    lastModifiedLedger: r.last_modified_ledger,
+    claimants: (r.claimants ?? []).map((c: any) => ({
+      destination: c.destination,
+      predicate: c.predicate,
+    })),
+  }));
+}

--- a/tests/unit/lib/claimableBalance.test.ts
+++ b/tests/unit/lib/claimableBalance.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Account, Keypair } from "@stellar/stellar-sdk";
+
+import {
+  buildPredicate,
+  createClaimableBalance,
+  claimClaimableBalance,
+  listClaimableBalances,
+  extractBalanceIdsFromTransactionResult,
+  MAX_CLAIMANTS_PER_BALANCE,
+  MAX_OPERATIONS_PER_TRANSACTION,
+  MAX_PREDICATE_DEPTH,
+  DEFAULT_TRANSACTION_TIMEOUT_SECONDS,
+  type ClaimPredicate,
+} from "../../../lib/claimableBalance";
+
+const TESTNET_HORIZON = "https://horizon-testnet.stellar.org";
+
+describe("claimableBalance.constants", () => {
+  it("exports protocol constants for downstream consumers", () => {
+    expect(MAX_CLAIMANTS_PER_BALANCE).toBe(10);
+    expect(MAX_OPERATIONS_PER_TRANSACTION).toBe(100);
+    expect(MAX_PREDICATE_DEPTH).toBeGreaterThan(0);
+    expect(DEFAULT_TRANSACTION_TIMEOUT_SECONDS).toBeGreaterThan(0);
+  });
+});
+
+describe("claimableBalance.buildPredicate", () => {
+  it("builds an unconditional predicate by default", () => {
+    expect(() => buildPredicate(undefined)).not.toThrow();
+    expect(() => buildPredicate({ type: "unconditional" })).not.toThrow();
+  });
+
+  it("validates relative-time predicates", () => {
+    expect(() =>
+      buildPredicate({ type: "beforeRelativeTime", seconds: 60 })
+    ).not.toThrow();
+    expect(() =>
+      buildPredicate({ type: "beforeRelativeTime", seconds: 0 })
+    ).toThrow(/positive integer/);
+    expect(() =>
+      buildPredicate({ type: "beforeRelativeTime", seconds: -1 as any })
+    ).toThrow(/positive integer/);
+  });
+
+  it("validates absolute-time predicates", () => {
+    expect(() =>
+      buildPredicate({ type: "beforeAbsoluteTime", epochSeconds: "1735689600" })
+    ).not.toThrow();
+    expect(() =>
+      buildPredicate({ type: "beforeAbsoluteTime", epochSeconds: "abc" as any })
+    ).toThrow(/positive integer/);
+  });
+
+  it("supports nested compound predicates", () => {
+    const predicate: ClaimPredicate = {
+      type: "and",
+      predicates: [
+        { type: "beforeRelativeTime", seconds: 100 },
+        { type: "not", predicate: { type: "unconditional" } },
+      ],
+    };
+    expect(() => buildPredicate(predicate)).not.toThrow();
+  });
+
+  it("rejects malformed compound predicates", () => {
+    expect(() =>
+      buildPredicate({ type: "and", predicates: [] as any })
+    ).toThrow(/exactly 2/);
+    expect(() => buildPredicate({ type: "not" } as any)).toThrow(/inner/);
+  });
+
+  it("guards against excessive nesting using the default cap", () => {
+    let p: ClaimPredicate = { type: "unconditional" };
+    for (let i = 0; i < MAX_PREDICATE_DEPTH + 3; i++) {
+      p = { type: "not", predicate: p };
+    }
+    expect(() => buildPredicate(p)).toThrow(/too deep/);
+  });
+
+  it("honours a custom max-depth override", () => {
+    const p: ClaimPredicate = {
+      type: "not",
+      predicate: { type: "not", predicate: { type: "unconditional" } },
+    };
+    expect(() => buildPredicate(p, 0, 1)).toThrow(/too deep/);
+    expect(() => buildPredicate(p, 0, 5)).not.toThrow();
+  });
+});
+
+describe("claimableBalance.extractBalanceIdsFromTransactionResult", () => {
+  it("returns empty array on malformed XDR", () => {
+    expect(extractBalanceIdsFromTransactionResult("not-xdr")).toEqual([]);
+  });
+
+  it("returns empty array when result_xdr is missing", () => {
+    expect(extractBalanceIdsFromTransactionResult("")).toEqual([]);
+  });
+});
+
+describe("claimableBalance.createClaimableBalance", () => {
+  const sourceKp = Keypair.random();
+  const destKp = Keypair.random();
+  let loadAccountSpy: any;
+  let submitSpy: any;
+
+  beforeEach(() => {
+    const account = new Account(sourceKp.publicKey(), "1");
+    const sdk = require("@stellar/stellar-sdk");
+    loadAccountSpy = vi
+      .spyOn(sdk.Horizon.Server.prototype as any, "loadAccount")
+      .mockResolvedValue(account);
+    submitSpy = vi
+      .spyOn(sdk.Horizon.Server.prototype as any, "submitTransaction")
+      .mockResolvedValue({
+        hash: "abc123",
+        // Empty result_xdr → balanceIds will be []. Real Horizon returns
+        // a populated XDR; integration tests cover end-to-end parsing.
+        result_xdr: "",
+      });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects bad amount", async () => {
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "XLM" },
+          amount: "0",
+          claimants: [{ destination: destKp.publicKey() }],
+        }
+      )
+    ).rejects.toThrow(/greater than zero/);
+  });
+
+  it("rejects empty claimants list", async () => {
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "XLM" },
+          amount: "10",
+          claimants: [],
+        }
+      )
+    ).rejects.toThrow(/At least one claimant/);
+  });
+
+  it("accepts more than 10 claimants — each becomes its own 1-claimant balance", async () => {
+    const claimants = Array.from({ length: 25 }, () => ({
+      destination: Keypair.random().publicKey(),
+    }));
+    const result = await createClaimableBalance(
+      { network: "testnet", horizonUrl: TESTNET_HORIZON },
+      {
+        sourceSecret: sourceKp.secret(),
+        asset: { code: "XLM" },
+        amount: "10",
+        claimants,
+      }
+    );
+    expect(result.transactionHash).toBe("abc123");
+    const submittedTx = submitSpy.mock.calls[0][0];
+    expect(submittedTx.operations).toHaveLength(25);
+  });
+
+  it("rejects more than the per-tx ops cap (default = MAX_OPERATIONS_PER_TRANSACTION)", async () => {
+    const claimants = Array.from(
+      { length: MAX_OPERATIONS_PER_TRANSACTION + 1 },
+      () => ({ destination: Keypair.random().publicKey() })
+    );
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "XLM" },
+          amount: "10",
+          claimants,
+        }
+      )
+    ).rejects.toThrow(new RegExp(`at most ${MAX_OPERATIONS_PER_TRANSACTION}`));
+  });
+
+  it("honours a custom maxOperationsPerTransaction override", async () => {
+    const claimants = Array.from({ length: 6 }, () => ({
+      destination: Keypair.random().publicKey(),
+    }));
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "XLM" },
+          amount: "10",
+          claimants,
+          options: { maxOperationsPerTransaction: 5 },
+        }
+      )
+    ).rejects.toThrow(/at most 5/);
+  });
+
+  it("requires issuer for non-native asset", async () => {
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "USDC" },
+          amount: "10",
+          claimants: [{ destination: destKp.publicKey() }],
+        }
+      )
+    ).rejects.toThrow(/issuer/);
+  });
+
+  it("submits a signed tx with one CreateClaimableBalance op per claimant", async () => {
+    const result = await createClaimableBalance(
+      { network: "testnet", horizonUrl: TESTNET_HORIZON },
+      {
+        sourceSecret: sourceKp.secret(),
+        asset: { code: "XLM" },
+        amount: "5",
+        claimants: [
+          {
+            destination: destKp.publicKey(),
+            predicate: { type: "beforeRelativeTime", seconds: 3600 },
+          },
+        ],
+      }
+    );
+
+    expect(result.transactionHash).toBe("abc123");
+    expect(Array.isArray(result.balanceIds)).toBe(true);
+    expect(loadAccountSpy).toHaveBeenCalledWith(sourceKp.publicKey());
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+
+    const submittedTx = submitSpy.mock.calls[0][0];
+    expect(submittedTx.signatures.length).toBeGreaterThan(0);
+    expect(submittedTx.operations).toHaveLength(1);
+    expect(submittedTx.operations[0].type).toBe("createClaimableBalance");
+  });
+
+  it("propagates Horizon submission failures", async () => {
+    submitSpy.mockRejectedValueOnce(new Error("tx_failed: op_underfunded"));
+    await expect(
+      createClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        {
+          sourceSecret: sourceKp.secret(),
+          asset: { code: "XLM" },
+          amount: "5",
+          claimants: [{ destination: destKp.publicKey() }],
+        }
+      )
+    ).rejects.toThrow(/op_underfunded/);
+  });
+});
+
+describe("claimableBalance.claimClaimableBalance", () => {
+  const claimerKp = Keypair.random();
+  let submitSpy: any;
+
+  beforeEach(() => {
+    const sdk = require("@stellar/stellar-sdk");
+    vi.spyOn(sdk.Horizon.Server.prototype as any, "loadAccount").mockResolvedValue(
+      new Account(claimerKp.publicKey(), "1")
+    );
+    submitSpy = vi
+      .spyOn(sdk.Horizon.Server.prototype as any, "submitTransaction")
+      .mockResolvedValue({ hash: "claim-hash", result_xdr: "" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects non-hex balance ids", async () => {
+    await expect(
+      claimClaimableBalance(
+        { network: "testnet", horizonUrl: TESTNET_HORIZON },
+        { claimerSecret: claimerKp.secret(), balanceId: "not-hex!" }
+      )
+    ).rejects.toThrow(/hex/);
+  });
+
+  it("submits a signed claim transaction", async () => {
+    const balanceId = "00000000" + "ab".repeat(32);
+    const result = await claimClaimableBalance(
+      { network: "testnet", horizonUrl: TESTNET_HORIZON },
+      { claimerSecret: claimerKp.secret(), balanceId }
+    );
+
+    expect(result.transactionHash).toBe("claim-hash");
+    expect(result.balanceId).toBe(balanceId);
+    const submittedTx = submitSpy.mock.calls[0][0];
+    expect(submittedTx.operations[0].type).toBe("claimClaimableBalance");
+  });
+});
+
+describe("claimableBalance.listClaimableBalances", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries Horizon with provided filters and maps records", async () => {
+    const sdk = require("@stellar/stellar-sdk");
+
+    const callBuilder: any = {
+      claimant: vi.fn().mockReturnThis(),
+      sponsor: vi.fn().mockReturnThis(),
+      asset: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      cursor: vi.fn().mockReturnThis(),
+      call: vi.fn().mockResolvedValue({
+        records: [
+          {
+            id: "00000000abc",
+            asset: "native",
+            amount: "10.0000000",
+            sponsor: "GSPONSOR",
+            last_modified_ledger: 42,
+            claimants: [
+              {
+                destination: "GDEST",
+                predicate: { unconditional: true },
+              },
+            ],
+          },
+        ],
+      }),
+    };
+
+    vi.spyOn(sdk.Horizon.Server.prototype as any, "claimableBalances").mockReturnValue(
+      callBuilder
+    );
+
+    const records = await listClaimableBalances(
+      { network: "testnet", horizonUrl: TESTNET_HORIZON },
+      { claimant: "GDEST", limit: 5 }
+    );
+
+    expect(callBuilder.claimant).toHaveBeenCalledWith("GDEST");
+    expect(callBuilder.limit).toHaveBeenCalledWith(5);
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe("00000000abc");
+    expect(records[0].claimants[0].destination).toBe("GDEST");
+  });
+});

--- a/tests/unit/tools/claimableBalance.test.ts
+++ b/tests/unit/tools/claimableBalance.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Account, Keypair } from "@stellar/stellar-sdk";
+
+import { StellarClaimableBalanceTool } from "../../../tools/claimableBalance";
+
+const sourceKp = Keypair.random();
+const claimerKp = Keypair.random();
+const recipient = Keypair.random().publicKey();
+
+describe("StellarClaimableBalanceTool", () => {
+  const previousPriv = process.env.STELLAR_PRIVATE_KEY;
+  const previousClaimer = process.env.STELLAR_CLAIMER_PRIVATE_KEY;
+
+  beforeEach(() => {
+    process.env.STELLAR_PRIVATE_KEY = sourceKp.secret();
+    process.env.STELLAR_CLAIMER_PRIVATE_KEY = claimerKp.secret();
+
+    const sdk = require("@stellar/stellar-sdk");
+    vi.spyOn(sdk.Horizon.Server.prototype as any, "loadAccount").mockResolvedValue(
+      new Account(sourceKp.publicKey(), "1")
+    );
+    vi.spyOn(sdk.Horizon.Server.prototype as any, "submitTransaction").mockResolvedValue({
+      hash: "tool-tx",
+      result_xdr: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousPriv === undefined) delete process.env.STELLAR_PRIVATE_KEY;
+    else process.env.STELLAR_PRIVATE_KEY = previousPriv;
+    if (previousClaimer === undefined) delete process.env.STELLAR_CLAIMER_PRIVATE_KEY;
+    else process.env.STELLAR_CLAIMER_PRIVATE_KEY = previousClaimer;
+  });
+
+  it("exposes a stable LangChain DynamicStructuredTool surface", () => {
+    expect(StellarClaimableBalanceTool.name).toBe("stellar_claimable_balance");
+    expect(typeof StellarClaimableBalanceTool.description).toBe("string");
+    expect(StellarClaimableBalanceTool.description.length).toBeGreaterThan(0);
+    expect(typeof StellarClaimableBalanceTool.func).toBe("function");
+  });
+
+  it("returns ok=false when create is missing required fields", async () => {
+    const out = await StellarClaimableBalanceTool.func({
+      action: "create",
+    } as any);
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/asset.*amount.*claimants/i);
+  });
+
+  it("create: routes through createClaimableBalance and returns the tx hash", async () => {
+    const out = await StellarClaimableBalanceTool.func({
+      action: "create",
+      asset: { code: "XLM" },
+      amount: "10",
+      claimants: [
+        {
+          destination: recipient,
+          predicate: { type: "beforeRelativeTime", seconds: 3600 },
+        },
+      ],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.transactionHash).toBe("tool-tx");
+    expect(Array.isArray(parsed.balanceIds)).toBe(true);
+  });
+
+  it("claim: rejects without balanceId", async () => {
+    const out = await StellarClaimableBalanceTool.func({ action: "claim" } as any);
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/balanceId/);
+  });
+
+  it("claim: routes through claimClaimableBalance and returns tx hash", async () => {
+    const balanceId = "00000000" + "ab".repeat(32);
+    const out = await StellarClaimableBalanceTool.func({
+      action: "claim",
+      balanceId,
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.transactionHash).toBe("tool-tx");
+  });
+
+  it("list: returns records via Horizon claimableBalances builder", async () => {
+    const sdk = require("@stellar/stellar-sdk");
+    const callBuilder: any = {
+      claimant: vi.fn().mockReturnThis(),
+      sponsor: vi.fn().mockReturnThis(),
+      asset: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      cursor: vi.fn().mockReturnThis(),
+      call: vi.fn().mockResolvedValue({
+        records: [
+          {
+            id: "abc",
+            asset: "native",
+            amount: "1.0000000",
+            last_modified_ledger: 1,
+            claimants: [],
+          },
+        ],
+      }),
+    };
+    vi.spyOn(sdk.Horizon.Server.prototype as any, "claimableBalances").mockReturnValue(
+      callBuilder
+    );
+
+    const out = await StellarClaimableBalanceTool.func({
+      action: "list",
+      filter: { claimant: recipient, limit: 5 },
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.records).toHaveLength(1);
+    expect(parsed.records[0].id).toBe("abc");
+    expect(callBuilder.claimant).toHaveBeenCalledWith(recipient);
+  });
+
+  it("create: returns ok=false when STELLAR_PRIVATE_KEY is missing", async () => {
+    delete process.env.STELLAR_PRIVATE_KEY;
+    const out = await StellarClaimableBalanceTool.func({
+      action: "create",
+      asset: { code: "XLM" },
+      amount: "10",
+      claimants: [{ destination: recipient }],
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/STELLAR_PRIVATE_KEY/);
+  });
+});

--- a/tools/claimableBalance.ts
+++ b/tools/claimableBalance.ts
@@ -1,0 +1,193 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import {
+  createClaimableBalance,
+  claimClaimableBalance,
+  listClaimableBalances,
+  type ClaimPredicate,
+} from "../lib/claimableBalance";
+
+// Environment configuration. Mirrors the convention used by other tools in
+// this directory (see ./contract.ts, ./bridge.ts).
+const STELLAR_NETWORK =
+  (process.env.STELLAR_NETWORK as "testnet" | "mainnet") || "testnet";
+
+const DEFAULT_HORIZON_URL =
+  STELLAR_NETWORK === "mainnet"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+
+const HORIZON_URL = process.env.HORIZON_URL || DEFAULT_HORIZON_URL;
+
+// ─── Zod schema (recursive predicate) ────────────────────────────────────
+//
+// We model the friendly tagged-union ClaimPredicate as a recursive Zod schema
+// using `z.lazy` so the AI agent can pass nested compound predicates.
+
+const predicateBaseSchema: z.ZodType<ClaimPredicate> = z.lazy(() =>
+  z.union([
+    z.object({ type: z.literal("unconditional") }),
+    z.object({
+      type: z.literal("beforeRelativeTime"),
+      seconds: z.union([z.number(), z.string()]),
+    }),
+    z.object({
+      type: z.literal("beforeAbsoluteTime"),
+      epochSeconds: z.union([z.number(), z.string()]),
+    }),
+    z.object({
+      type: z.literal("not"),
+      predicate: predicateBaseSchema,
+    }),
+    z.object({
+      type: z.literal("and"),
+      predicates: z.tuple([predicateBaseSchema, predicateBaseSchema]),
+    }),
+    z.object({
+      type: z.literal("or"),
+      predicates: z.tuple([predicateBaseSchema, predicateBaseSchema]),
+    }),
+  ])
+);
+
+const assetSchema = z.object({
+  code: z.string().describe("Asset code (use 'XLM' or 'native' for the native asset)"),
+  issuer: z
+    .string()
+    .optional()
+    .describe("Issuer public key (required for non-native assets)"),
+});
+
+const claimantSchema = z.object({
+  destination: z.string().describe("Recipient public key"),
+  predicate: predicateBaseSchema.optional().describe(
+    "Optional claim predicate. Omit for unconditional. " +
+      "Examples: { type: 'beforeRelativeTime', seconds: 86400 }, " +
+      "{ type: 'and', predicates: [<a>, <b>] }"
+  ),
+});
+
+const inputSchema = z.object({
+  action: z
+    .enum(["create", "claim", "list"])
+    .describe(
+      "Operation to perform: create a new claimable balance, claim an existing one, or list balances."
+    ),
+  // create
+  asset: assetSchema.optional(),
+  amount: z
+    .string()
+    .optional()
+    .describe("Amount to lock (positive decimal with up to 7 fractional digits)"),
+  claimants: z
+    .array(claimantSchema)
+    .optional()
+    .describe("List of claimants with optional predicates"),
+  // claim
+  balanceId: z
+    .string()
+    .optional()
+    .describe("Hex-encoded claimable balance id to claim"),
+  // list
+  filter: z
+    .object({
+      claimant: z.string().optional(),
+      sponsor: z.string().optional(),
+      asset: assetSchema.optional(),
+      limit: z.number().int().positive().max(200).optional(),
+    })
+    .optional(),
+});
+
+type ToolInput = z.infer<typeof inputSchema>;
+
+function getSecretFromEnv(varName: string): string {
+  const v = process.env[varName];
+  if (!v) throw new Error(`Missing ${varName} in environment`);
+  return v;
+}
+
+/**
+ * LangChain `DynamicStructuredTool` that exposes Stellar Claimable Balances
+ * (create / claim / list) to AI agents. Read-only `list` requires no secret;
+ * `create` reads `STELLAR_PRIVATE_KEY`; `claim` reads `STELLAR_CLAIMER_PRIVATE_KEY`
+ * (falling back to `STELLAR_PRIVATE_KEY` if unset).
+ *
+ * @example agent prompt:
+ *   "Lock 50 XLM for GABCD... claimable any time within the next 2 hours."
+ */
+export const StellarClaimableBalanceTool = new DynamicStructuredTool({
+  name: "stellar_claimable_balance",
+  description:
+    "Create, claim, or list Stellar Claimable Balances — conditional / time-locked payments " +
+    "(escrow, vesting, scheduled payouts). Supports composable predicates: unconditional, " +
+    "beforeRelativeTime, beforeAbsoluteTime, and/or/not.",
+  schema: inputSchema,
+  func: async (input: ToolInput) => {
+    const ctx = { network: STELLAR_NETWORK, horizonUrl: HORIZON_URL };
+
+    try {
+      switch (input.action) {
+        case "create": {
+          if (!input.asset || !input.amount || !input.claimants) {
+            throw new Error(
+              "`create` requires `asset`, `amount`, and `claimants`"
+            );
+          }
+          const sourceSecret = getSecretFromEnv("STELLAR_PRIVATE_KEY");
+          const result = await createClaimableBalance(ctx, {
+            sourceSecret,
+            asset: input.asset,
+            amount: input.amount,
+            claimants: input.claimants,
+          });
+          return JSON.stringify(
+            {
+              ok: true,
+              transactionHash: result.transactionHash,
+              balanceIds: result.balanceIds,
+            },
+            null,
+            2
+          );
+        }
+
+        case "claim": {
+          if (!input.balanceId) {
+            throw new Error("`claim` requires `balanceId`");
+          }
+          const claimerSecret =
+            process.env.STELLAR_CLAIMER_PRIVATE_KEY ||
+            getSecretFromEnv("STELLAR_PRIVATE_KEY");
+          const result = await claimClaimableBalance(ctx, {
+            claimerSecret,
+            balanceId: input.balanceId,
+          });
+          return JSON.stringify(
+            { ok: true, transactionHash: result.transactionHash },
+            null,
+            2
+          );
+        }
+
+        case "list": {
+          const records = await listClaimableBalances(ctx, input.filter ?? {});
+          return JSON.stringify({ ok: true, records }, null, 2);
+        }
+
+        default: {
+          // Exhaustiveness guard
+          const exhaustive: never = input.action;
+          throw new Error(`Unsupported action: ${String(exhaustive)}`);
+        }
+      }
+    } catch (error) {
+      const message =
+        (error as { response?: { data?: { title?: string } }; message?: string })
+          ?.response?.data?.title ||
+        (error as Error).message ||
+        "Unknown error";
+      return JSON.stringify({ ok: false, error: message }, null, 2);
+    }
+  },
+});


### PR DESCRIPTION
## feat: add Claimable Balance support across lib, AgentClient, and LangChain tool

### What

First-class support for **Stellar Claimable Balances** — a unique Stellar
primitive for conditional / time-locked payments (escrow, vesting,
scheduled payouts). Previously absent from the kit. Particularly valuable
for AI-agent workflows that release funds only when a predicate is
satisfied.

### Why

Every existing kit feature (bridge, swap, stake, payment, balance) ships a
LangChain `DynamicStructuredTool` and is bundled into `stellarTools`.
Claimable balances unlock new agentic use-cases (escrow, vesting, retry
deadlines) that none of the existing tools cover.

### Surfaces

1. **Programmatic** — `agent.claimable.{create,claim,list}` on [AgentClient](cci:2://file:///e:/stellar_journey/opensource/stellar_agent_kit/agent.ts:94:0-647:1)
2. **LangChain Tool** — `StellarClaimableBalanceTool`, auto-included in `stellarTools`
3. **Lower-level** — `lib/claimableBalance` (functions + [buildPredicate](cci:1://file:///e:/stellar_journey/opensource/stellar_agent_kit/lib/claimableBalance.ts:174:0-240:1) + constants)

### Highlights

- Friendly tagged-union [ClaimPredicate](cci:2://file:///e:/stellar_journey/opensource/stellar_agent_kit/lib/claimableBalance.ts:34:0-40:65) (unconditional / beforeRelativeTime
  / beforeAbsoluteTime / not / and / or) with input validation, depth guard,
  and amount/issuer checks
- 1:1 claimant-to-operation mapping for deterministic balance-id extraction
- All Stellar protocol limits exposed as named exports + overridable via
  per-call `options` (no magic numbers)
- Tool always returns JSON (`{ ok, ... }`) for deterministic agent parsing
- Recursive zod schema so agents can pass nested compound predicates

### Tests

- [tests/unit/lib/claimableBalance.test.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/tests/unit/lib/claimableBalance.test.ts:0:0-0:0) (21 tests)
- [tests/unit/tools/claimableBalance.test.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/tests/unit/tools/claimableBalance.test.ts:0:0-0:0) (7 tests)
- All 87 tests pass; `tsc --noEmit` clean

### Files

- [lib/claimableBalance.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/lib/claimableBalance.ts:0:0-0:0) (new)
- [tools/claimableBalance.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/tools/claimableBalance.ts:0:0-0:0) (new)
- [examples/claimable-balance-example.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/examples/claimable-balance-example.ts:0:0-0:0) (new)
- [tests/unit/lib/claimableBalance.test.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/tests/unit/lib/claimableBalance.test.ts:0:0-0:0) (new)
- [tests/unit/tools/claimableBalance.test.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/tests/unit/tools/claimableBalance.test.ts:0:0-0:0) (new)
- [agent.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/agent.ts:0:0-0:0) (added `claimable` namespace + type re-exports)
- [index.ts](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/index.ts:0:0-0:0) (export tool, types, constants; add to `stellarTools`)
- [README.md](cci:7://file:///e:/stellar_journey/opensource/stellar_agent_kit/README.md:0:0-0:0) (new "Claimable Balances" section)