### PR TITLE
docs: add account utilities documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,56 @@ const shareId = await agent.lp.getShareId();
   - **Classic best-route swaps (`agent.dex.*`):** Require `allowMainnet: true` in `AgentClient`
   - **Soroban single-pool swap/LP (`agent.swap()`, `agent.lp.*`):** Still wired to testnet-only contract settings
   - **Bridge operations:** Require BOTH `allowMainnet: true` AND `ALLOW_MAINNET_BRIDGE=true` in `.env`
+---
+
+## 🔍 Account Utilities
+
+AgentKit provides built-in tools for querying Stellar account balances and account details.
+
+### Get Account Balance
+
+```typescript
+import { stellarTools } from "stellartools";
+
+// Example input
+{
+  publicKey: "GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  network: "testnet"
+}
+```
+
+Returns balances for XLM and all trustline assets associated with the account.
+
+### Get Account Information
+
+```typescript
+import { stellarTools } from "stellartools";
+
+// Example input
+{
+  publicKey: "GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  network: "testnet"
+}
+```
+
+Returns account metadata including:
+
+* Sequence number
+* Thresholds
+* Signers
+* Account flags
+* Other Horizon account details
+
+### Supported Networks
+
+Both account utilities support:
+
+* `testnet`
+* `mainnet`
+
+The default network is `testnet`.
+
+
 
 ---
 


### PR DESCRIPTION
## Summary

This PR improves the README by documenting the built-in Stellar account utility tools that were already implemented but not previously documented.

### Changes

* Added a new Account Utilities section to the README
* Added usage examples for `stellar_get_balance`
* Added usage examples for `stellar_get_account_info`
* Documented supported networks and default behavior

### Impact

This improves developer onboarding and discoverability of account-related functionality within Stellar AgentKit, making it easier for developers to use balance lookup and account information tools.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the built-in Stellar account utilities in the README with clear examples for balance lookup and account details. Covers `stellar_get_balance`, `stellar_get_account_info`, supported networks (`testnet`, `mainnet`), and the default `testnet` behavior to improve onboarding and discoverability.

<sup>Written for commit a62011209205f2bd7ce25d13bed7ebdab3656d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Stellar-Tools/Stellar-AgentKit/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

